### PR TITLE
updates for ET-380 and ET-381 discard create experiment buttons

### DIFF
--- a/app/routes/app.experiments.new.jsx
+++ b/app/routes/app.experiments.new.jsx
@@ -50,6 +50,7 @@ export default function CreateExperiment() {
   return (
     <s-page heading="Create Experiment">
       <s-button slot="primary-action" variant="primary">Save Draft</s-button> 
+      <s-button slot="secondary-actions" href="/app/experiments">Discard</s-button>
       <s-section>
         <s-form>
         <s-text-area
@@ -60,7 +61,10 @@ export default function CreateExperiment() {
               onChange={(e) => setDescription(e.target.value)} 
             />
             {error && <s-paragraph tone="critical">{error}</s-paragraph>}
-        <s-button onClick={handleExperimentCreate}>Save experiment</s-button>
+        <s-stack direction="inline" gap="base">
+          <s-button href="/app/experiments">Discard</s-button>
+          <s-button variant="primary" onClick={handleExperimentCreate}>Save experiment</s-button>
+        </s-stack>
         </s-form>
       </s-section>
 


### PR DESCRIPTION
Added discard button in the create experiment screen in the header and footer that brings user back to the create experiments page and does not save the draft