### PR TITLE
ET-171 Add experiment section ID

### DIFF
--- a/app/routes/app.experiments.new.jsx
+++ b/app/routes/app.experiments.new.jsx
@@ -204,12 +204,12 @@ export default function CreateExperiment() {
                     Section ID to be tested
                   </s-text>
                 </s-box>
-                <s-link href="https://www.youtube.com/watch?v=Aq5WXmQQooo&list=RDAq5WXmQQooo&start_radio=1" target="_blank"> 
+                <s-link href="#" target="_blank"> 
                   How do I find my section?
                 </s-link>
               </s-stack>
           <s-text-field
-            placeholder="Enter Shopify section ID"
+            placeholder="shopify-section-sections--25210977943842__header"
             value={sectionId}
             onChange={(e) => setSectionId(e.target.value)}
             details="The associated Shopify section ID to be tested. Must be visible on production site"


### PR DESCRIPTION
Under the experiment details section, a Section ID text-field functionality was implemented. 
There is placeholder text where the user should enter their desired Shopify section ID for their current experiment.

A convenient hyperlink was added so that users can find their Shopify section ID's. 