### PR TITLE
feat: added simple lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,23 @@
+name: lint
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v4
+      - name: Set Up NodeJS
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.20.0'
+      - name: Install Dependencies
+        run: npm ci
+      - name: Run Linter
+        run: npm run lint
+      


### PR DESCRIPTION
I am experimenting with creating a CI pipeline. I've added a very small workflow that performs a lint check using the autogenerated script in `package,json`. For now, all workflows are on manual triggers only. A finished implementation would have them run on every pull request that targets `main`. 

