### PR TITLE
Et 420 handle date change update

### DIFF
--- a/app/routes/app.experiments.new.jsx
+++ b/app/routes/app.experiments.new.jsx
@@ -425,7 +425,7 @@ function validateEndIsAfterStart(
       dateError = "End date must be after the start date";
     } else {
       // same day but time invalid -> show error on time
-      timeError = "End must be after the start time";
+      timeError = "End time must be after the start time";
     }
   }
   return { dateError, timeError };


### PR DESCRIPTION
- added client-side validation logic for startDate and endDate 
- added a useEffect hook to check for time/date mismatch errors in between renders
- added server-side validation for startDate and endDate 

Big Caveat: Assumes endCondition bug was fixed, currently the server-side looks broken, but with @RicePaperDolls 's endCondition fix which allows the endCondition field to be properly saved to the DB, my endDate validation should run, and it should save to the DB. As is, Prisma flags the endDate as invalid, and sets to null for safety.