### PR TITLE
ET-12 Experiment List Quick Access Bar

### DIFF
--- a/app/routes/app.experiments._index.jsx
+++ b/app/routes/app.experiments._index.jsx
@@ -148,34 +148,30 @@ export default function Experimentsindex() {
             </s-button>
             <s-popover id={`popover-${curExp.id}`}>
               <s-stack direction="block">
-                {/* Adding command="hide" ensures the popover closes when the button is clicked */}
+                {/* command="hide" closes the popover when the button is clicked */}
                 <s-button 
                   variant="tertiary" 
-                  command="hide" 
-                  commandTarget={`popover-${curExp.id}`}
+                  commandFor={`popover-${curExp.id}`}
                 >
                   Rename
                 </s-button>
                 <s-button 
                   variant="tertiary" 
-                  command="hide" 
-                  commandTarget={`popover-${curExp.id}`}
-                >
-                  Archive
-                </s-button>
-                <s-button 
-                  variant="tertiary" 
-                  command="hide" 
-                  commandTarget={`popover-${curExp.id}`}
+                  commandFor={`popover-${curExp.id}`}
                 >
                   Pause
                 </s-button>
                 <s-button 
                   variant="tertiary" 
-                  command="hide" 
-                  commandTarget={`popover-${curExp.id}`}
+                  commandFor={`popover-${curExp.id}`}
                 >
                   Resume
+                </s-button>
+                <s-button 
+                  variant="tertiary" 
+                  commandFor={`popover-${curExp.id}`}
+                >
+                  Archive
                 </s-button>
               </s-stack>
             </s-popover>


### PR DESCRIPTION
Implements a contextual Quick Access Bar for the Experiment Management list. Users can now click experiment states (Rename, Pause, Resume, Archive) directly from the table view. Functionality will be added in the near future.

The sub-menu closes when the user makes a selection or when they click outside of the sub-menu. The user can choose between Rename, Pause, Resume, and Archive.

<img width="1173" height="455" alt="image" src="https://github.com/user-attachments/assets/7bdcaccd-c967-4a5e-9df6-250a55928964" />

