### PR TITLE
Default Experiment Goal Functionality

### DIFF
--- a/app/routes/app.experiments.new.jsx
+++ b/app/routes/app.experiments.new.jsx
@@ -14,7 +14,7 @@ if (typeof window !== 'undefined') {
 }
 
 import { authenticate } from "../shopify.server";
-import { useFetcher, redirect } from "react-router";
+import { useFetcher, redirect, useLoaderData } from "react-router";
 import { useState, useEffect } from "react";
 import db from "../db.server";
 
@@ -223,6 +223,16 @@ export const action = async ({ request }) => {
   const experiment = await createExperiment(experimentData);
 
   return redirect(`/app/experiments/${experiment.id}`);
+};
+
+//pull the default goal stored in database, completedCheckout if empty
+export const loader = async ({ request }) => {
+  const { session } = await authenticate.admin(request);
+  const project = await db.project.findUnique({
+    where: { shop: session.shop },
+    select: { defaultGoal: true },
+  });
+  return { defaultGoal: project?.defaultGoal ?? "completedCheckout" };
 };
 
 //--------------------------- client side ----------------------------------------
@@ -469,6 +479,7 @@ function localDateTimeToISOString(dateStr, timeStr = "00:00") {
 export default function CreateExperiment() {
   //fetcher stores the data in the fields into a form that can be retrieved
   const fetcher = useFetcher();
+  const { defaultGoal } = useLoaderData();
 
   //state variables (special variables that remember across re-renders (e.g. user input, counters))
   const [name, setName] = useState("");
@@ -484,7 +495,7 @@ export default function CreateExperiment() {
   const [endDateError, setEndDateError] = useState("");
   const [experimentChance, setExperimentChance] = useState(50);
   const [endCondition, setEndCondition] = useState("manual");
-  const [goalSelected, setGoalSelected] = useState("completedCheckout");
+  const [goalSelected, setGoalSelected] = useState(defaultGoal);
   const [customerSegment, setCustomerSegment] = useState("allSegments");
   const [variant, setVariant] = useState(false);
   const [variantDisplay, setVariantDisplay] = useState("none");

--- a/app/routes/app.settings.jsx
+++ b/app/routes/app.settings.jsx
@@ -1,9 +1,69 @@
-export default function Reports() {
-    return (
-        <s-page heading="App Settings">
-            <s-section heading="Support & Doccumentation">
-                <s-link href="/app/help">How To's and Support</s-link>
-            </s-section>
-        </s-page>
-    );
+//imports
+import { authenticate } from "../shopify.server";
+import { useLoaderData, useFetcher } from "react-router";
+import db from "../db.server";
+
+//loader for the default goal
+export const loader = async ({ request }) => {
+  const { session } = await authenticate.admin(request);
+  const project = await db.project.findUnique({
+    where: { shop: session.shop },
+    select: { defaultGoal: true },
+  });
+  return { defaultGoal: project?.defaultGoal ?? "completedCheckout" };
+};
+
+//write updated experiment goal to database
+export const action = async ({ request }) => {
+  const { session } = await authenticate.admin(request);
+  //retrieve and parse data
+  const formData = await request.formData();
+  const defaultGoal = (formData.get("defaultGoal") || "").trim();
+  //update or create default goal in database
+  await db.project.upsert({
+    where: { shop: session.shop },
+    update: { defaultGoal },
+    create: { shop: session.shop, name: `${session.shop} Project`, defaultGoal },
+  });
+};
+
+export default function Settings() {
+  const { defaultGoal } = useLoaderData();
+  const fetcher = useFetcher();
+
+  return (
+    <s-page heading="App Settings">
+      <s-section heading="Experiment Configuration">
+        <fetcher.Form method="post">
+          <s-stack direction="block" gap="base">
+            <s-select
+              label="Select a new default goal for creating new experiments"
+              name="defaultGoal"
+              value={defaultGoal}
+              //NOTE: this on change element will need to be modified when a dedicated save button is implemented for the settings page
+              onChange={(e) =>
+                fetcher.submit(
+                  { defaultGoal: e.target.value },
+                  { method: "post" }
+                )
+              }
+            >
+              <s-option value="completedCheckout">Completed Checkout</s-option>
+              <s-option value="viewPage">Viewed Page</s-option>
+              <s-option value="startCheckout">Started Checkout</s-option>
+              <s-option value="addToCart">Added Product to Cart</s-option>
+            </s-select>
+          </s-stack>
+        </fetcher.Form>
+      </s-section>
+      <s-section heading="Support & Documentation">
+        <s-link href="/app/help">How To's and Support</s-link>
+      </s-section>
+      <s-section heading="Language">
+        <s-select name="language">
+            <s-option value="English">English</s-option>
+        </s-select>
+      </s-section>
+    </s-page>
+  );
 }

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model Project {
   shop       String   @unique
   name       String?
   created_at DateTime @default(now()) @map("created_at")
+  defaultGoal String  @default("completedCheckout") @map("default_goal")
 
   experiments Experiment[] // Virtual Field indicating "look @ the experiment model/table for any row that points back to me"
   audiences   Audience[] // List[] uses Foregin keys as links to models to know where to look


### PR DESCRIPTION
Note: changes have been made to Prisma Schema, please run npx prisma migrate dev --name add_default_goal_to_project

-added selection on settings page that saves default experiment goal to newly added section in the database
-on create new experiment page, the default experiment goal is loaded in from the database and set to the default for that s-selection