### PR TITLE
Et 457 experiment reports recommended course of action

### DIFF
--- a/app/routes/app.experiments._index.jsx
+++ b/app/routes/app.experiments._index.jsx
@@ -158,6 +158,8 @@ export default function Experimentsindex() {
       //single tuple of the experiment data
       const curExp = experiments[i];
 
+      const resumeLabel = curExp.startDate ? "Resume" : "Start";
+
       // call formatRuntime utility
       const runtime = formatRuntime(
         curExp.startDate,
@@ -199,17 +201,18 @@ export default function Experimentsindex() {
                 <s-button 
                   variant="tertiary" 
                   commandFor={`popover-${curExp.id}`}
+                  disabled={curExp.status === "active" || fetcher.state !== "idle"}
                   onClick={() => {
                     fetcher.submit(
                       {
-                        intent: "rename",
+                        intent: "resume",
                         experimentId: curExp.id
                       },
                       { method: "post" }
                     );
                   }}
                 >
-                  Rename
+                  {resumeLabel}
                 </s-button>
                 <s-button 
                   variant="tertiary" 
@@ -231,18 +234,17 @@ export default function Experimentsindex() {
                 <s-button 
                   variant="tertiary" 
                   commandFor={`popover-${curExp.id}`}
-                  disabled={curExp.status === "active" || fetcher.state !== "idle"}
                   onClick={() => {
                     fetcher.submit(
                       {
-                        intent: "resume",
+                        intent: "rename",
                         experimentId: curExp.id
                       },
                       { method: "post" }
                     );
                   }}
                 >
-                  Resume
+                  Rename
                 </s-button>
                 <s-button 
                   variant="tertiary" 

--- a/app/routes/app.reports.$id.jsx
+++ b/app/routes/app.reports.$id.jsx
@@ -75,7 +75,7 @@ export default function Report() {
     if (val === null || val === undefined) return "-";
     return ( val * 100 ).toFixed(2)+"%";
   }
-  
+
   // Table code
   function renderTableData() {
     const rows = [];
@@ -204,47 +204,57 @@ export default function Report() {
   const heading = experiment?.name ? `Report - ${experiment.name}` : "Report";
   return (
     <s-page heading={heading}>
-      <s-button
-        slot="primary-action"
-        href={`/app/experiments/${experiment.id}`}
-      >
+      {/* Action button */}
+      <s-button slot="primary-action" href={`/app/experiments/${experiment.id}`}>
         Edit Experiment
       </s-button>
-      <div style={{ marginBottom: "16px", marginTop: "16px" }}>
-        <s-heading>Experiment Reports</s-heading>
-        <DateRangePicker />
-        {dateRange && (
-          <s-text tone="subdued">
-            Viewing data from {formatDateForDisplay(dateRange.start)} to{" "}
-            {formatDateForDisplay(dateRange.end)}
-          </s-text>
-        )}
-        {/*appears to be graph page render data */}
-        
+      <div 
+      slot = "aside"
+      style = {{
+        position: 'sticky', // sticks to the scroll wheel
+        top: '1rem',
+        alignSelf: 'flex-start',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: '1rem',        // space between details & recommendation 
+        width: '250px',
+        }}>
+          <s-section heading="Recommendation">
+            <s-stack gap="small">
+              <div style={{
+                padding:'12px',
+                borderRadius:'8px',
+                borderLeft:'4px solid' // visual indicator for win/inconclusive
+                }}>
+                  <s-text font-weight="heavy"> Status Message </s-text>
+                  <s-text size="small" tone="subued"> Description </s-text>
+              </div>
+            </s-stack>
+          </s-section>
       </div>
-      <s-section> {/*might be broken */}
-          <s-heading>Variant Success Rate</s-heading>
-
-          {/* Table Section of experiment list page */}
-          <s-box  background="base"
-                  border="base"
-                  borderRadius="base"
-                  overflow="hidden"> {/*box used to provide a curved edge table */}
-            <s-table>
-              <s-table-header-row>
-                <s-table-header listslot='primary'>Variant Name</s-table-header>
-                <s-table-header listSlot="secondary">Goal Completion Rate</s-table-header>
-                <s-table-header listSlot="labeled">Improvement %</s-table-header>
-                <s-table-header listSlot="labeled" format="numeric">Probability to be Best</s-table-header>
-                <s-table-header listSlot="labeled" format="numeric">Expected Loss</s-table-header>
-                <s-table-header listSlot="labeled" >Goal Completion / Visitor</s-table-header>
-              </s-table-header-row>
-                <s-table-body>
-                  {renderTableData()}
-                </s-table-body>
-              </s-table>
-          </s-box> {/*end of table section*/}
-        </s-section>
+      
+      <s-section> {/* Variant Success Rate [might be broken - Paul]*/}
+      <s-heading>Variant Success Rate</s-heading>
+        {/* Table Section of experiment list page */}
+        <s-box  background="base"
+                border="base"
+                borderRadius="base"
+                overflow="hidden"> {/*box used to provide a curved edge table */}
+          <s-table>
+            <s-table-header-row>
+              <s-table-header listslot='primary'>Variant Name</s-table-header>
+              <s-table-header listSlot="secondary">Goal Completion Rate</s-table-header>
+              <s-table-header listSlot="labeled">Improvement %</s-table-header>
+              <s-table-header listSlot="labeled" format="numeric">Probability to be Best</s-table-header>
+              <s-table-header listSlot="labeled" format="numeric">Expected Loss</s-table-header>
+              <s-table-header listSlot="labeled" >Goal Completion / Visitor</s-table-header>
+            </s-table-header-row>
+              <s-table-body>
+                {renderTableData()}
+              </s-table-body>
+            </s-table>
+        </s-box> {/*end of table section*/}
+      </s-section>
       <s-section heading="Probability To Be The Best">
         {isClient ? (
           <ResponsiveContainer width="100%" height={400}>
@@ -330,4 +340,4 @@ export default function Report() {
       </s-section>
     </s-page>
   );
-}
+  }

--- a/app/services/experiment.server.js
+++ b/app/services/experiment.server.js
@@ -60,11 +60,11 @@ export async function pauseExperiment(experimentId){
     where: { id },
     data: {
       status: "paused",
+      endDate: new Date(),
       history: {
         create: {
           prevStatus: prevStatus,
           newStatus: "paused",
-          // changedAt defaults to now() per Prisma schema
         },
       },
     },
@@ -107,11 +107,11 @@ export async function archiveExperiment(experimentId){
     where: { id },
     data: {
       status: "archived",
+      endDate: experiment.endDate || new Date(),
       history: {
         create: {
           prevStatus: prevStatus,
           newStatus: "archived",
-          // changedAt defaults to now() per Prisma schema
         },
       },
     },
@@ -144,6 +144,7 @@ export async function resumeExperiment(experimentId) {
     where: { id },
     data: {
       status: "active", // Resuming typically moves it back to active
+      startDate: experiment.startDate || new Date(),
       history: {
         create: {
           prevStatus: prevStatus,


### PR DESCRIPTION
This PR implements ET-457, ET-466, and ET-467, introducing a dynamic Recommended Course of Action panel to the experiment reports.

- Returns winner only if Probability to be Best >= 80% && Goal Completion Rate delta >1%
-  The analyses table is scanned to detect if a variant hit 80% previously, providing context for "Continue Testing" during temporary dips.
- Otherwise returns, "Keep Testing", if an experiment is still on going and has yet to stabilize
- Added logic branches to handle recommendations for active, completed, paused, and draft statuses.
- Utilizes `<s-banner>` with dynamic `tone` mapping (success, info, warning) for a native Shopify admin dashboard feel.
- Implemented a sticky div wrapper for the aside slot to ensure the recommendation remains visible during scrolling.
-  basic details about the experiment and winning variant is provided.

PS: Use `npm run seed:demo` to test

<img width="1034" height="739" alt="image" src="https://github.com/user-attachments/assets/c332e720-e84a-4b13-a6ba-66d42a54b42b" />
<img width="1023" height="736" alt="image" src="https://github.com/user-attachments/assets/ed142871-e955-4e97-92e6-28be9b00f44b" />
<img width="1281" height="760" alt="image" src="https://github.com/user-attachments/assets/c284c17a-e534-46de-b7ed-3dc2a97d4046" />
