### PR TITLE
Fixed Discard button to clear fields

### DIFF
--- a/app/routes/app.experiments.new.jsx
+++ b/app/routes/app.experiments.new.jsx
@@ -1357,7 +1357,7 @@ export default function CreateExperiment() {
           <s-button 
             onClick={handleDiscard}
             variant="secondary">
-            Discardo
+            Discard
           </s-button>
           <s-button 
             variant="primary" 

--- a/app/routes/app.experiments.new.jsx
+++ b/app/routes/app.experiments.new.jsx
@@ -808,6 +808,41 @@ export default function CreateExperiment() {
     setVariantExperimentChance();
   };
 
+  const handleDiscard = () => {
+    setName("");
+    setDescription("");
+    setSectionId("");
+    setVariant(false);
+    setVariantDisplay("none");
+    setVariantSectionId("");
+    setExperimentChance(50);
+    setVariantExperimentChance(50);
+    setGoalSelected(defaultGoal);
+    setCustomerSegment("allSegments");
+    setEndCondition("manual");
+    setStartDate("");
+    setStartTime("12:00");
+    setEndDate("");
+    setEndTime("11:59 PM");
+    setProbabilityToBeBest("");
+    setDuration("");
+    setTimeUnit("days");
+
+    setNameError(null);
+    setDescriptionError(null);
+    setSectionIdError(null);
+    setSectionIdVariantError(null);
+    setEmptyStartDateError(null);
+    setEmptyEndDateError(null);
+    setStartDateError("");
+    setStartTimeError("");
+    setEndDateError("");
+    setEndTimeError("");
+    setProbabilityToBeBestError("");
+    setDurationError("");
+    setTimeUnitError("");
+  };
+
   
   const descriptionError = errors.description;
 
@@ -852,8 +887,11 @@ export default function CreateExperiment() {
       >
         Save Draft
       </s-button>
-      <s-button slot="secondary-actions" href="/app/experiments">
+      <s-button slot="secondary-actions" onClick={handleDiscard}>
         Discard
+      </s-button>
+      <s-button slot="secondary-actions" href="/app/experiments">
+        Back to Experiment List
       </s-button>
       {(errors.form || errors.goal) && (
         <s-box padding="base">
@@ -1316,7 +1354,11 @@ export default function CreateExperiment() {
       </s-section>
       <div style={{ marginBottom: "250px" }}>
         <s-stack direction="inline" gap="small" justifyContent="end">
-          <s-button href="/app/experiments">Discard</s-button>
+          <s-button 
+            onClick={handleDiscard}
+            variant="secondary">
+            Discardo
+          </s-button>
           <s-button 
             variant="primary" 
             disabled={hasClientErrors || isSubmitting} 


### PR DESCRIPTION
Discard buttons both now clear and reset all the fields for the create experiment page. Also added a button to be able to navigate to the experiments list page so user is not stuck on the new experiment page