### PR TITLE
ET-524 add per-variant traffic allocation

### DIFF
--- a/prisma/migrations/20260303194226_add_variant_traffic_allocation/migration.sql
+++ b/prisma/migrations/20260303194226_add_variant_traffic_allocation/migration.sql
@@ -1,0 +1,44 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Variant" (
+    "variant_id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "name" TEXT NOT NULL,
+    "description" TEXT,
+    "config_data" JSONB,
+    "experiment_id" INTEGER NOT NULL,
+    "trafficAllocation" DECIMAL NOT NULL DEFAULT 0,
+    CONSTRAINT "Variant_experiment_id_fkey" FOREIGN KEY ("experiment_id") REFERENCES "Experiment" ("experiment_id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+INSERT INTO "new_Variant" ("config_data", "description", "experiment_id", "name", "variant_id") SELECT "config_data", "description", "experiment_id", "name", "variant_id" FROM "Variant";
+DROP TABLE "Variant";
+ALTER TABLE "new_Variant" RENAME TO "Variant";
+
+-- BEGIN MANUAL MIGRATION SECTION
+-- Backfill trafficAllocation from experiment trafficSplit
+-- Control gets (1 - trafficSplit), each non-control variant gets trafficSplit / (N - 1)
+UPDATE "Variant"
+SET "trafficAllocation" = CASE
+  WHEN "name" = 'Control' THEN
+    1.0 - (
+      SELECT e."traffic_split"
+      FROM "Experiment" e
+      WHERE e."experiment_id" = "Variant"."experiment_id"
+    )
+  ELSE
+    (
+      SELECT e."traffic_split"
+      FROM "Experiment" e
+      WHERE e."experiment_id" = "Variant"."experiment_id"
+    ) / (
+      (
+        SELECT COUNT(*)
+        FROM "Variant" v2
+        WHERE v2."experiment_id" = "Variant"."experiment_id"
+      ) - 1.0
+    )
+  END;
+
+-- END MANUAL MIGRATION SECTION
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -166,6 +166,7 @@ model Variant {
 
   experimentId Int        @map("experiment_id") // Foreign key
   experiment   Experiment @relation(fields: [experimentId], references: [id], onDelete: Cascade) // connects to Experiment's PK
+  trafficAllocation Decimal @default(0) // How much traffic is allocated to this variant of the experiment
 
   allocations Allocation[]
   conversions Conversion[]

--- a/prisma/seed.base.js
+++ b/prisma/seed.base.js
@@ -210,6 +210,9 @@ export async function seedBase(prisma) {
     const exp = experiments[i];
     const base = variantConfigs[i];
 
+    const controlAllocation = 1.0 - exp.trafficSplit;
+    const variantAllocation = exp.trafficSplit;
+
     await prisma.variant.upsert({
       where: { id: base.idStart },
       update: {
@@ -217,6 +220,7 @@ export async function seedBase(prisma) {
         description: 'Control variant',
         configData: base.control,
         experimentId: exp.id,
+        trafficAllocation: controlAllocation,
       },
       create: {
         id: base.idStart,
@@ -224,6 +228,7 @@ export async function seedBase(prisma) {
         description: 'Control variant',
         configData: base.control,
         experimentId: exp.id,
+        trafficAllocation: controlAllocation,
       },
     });
 
@@ -234,6 +239,7 @@ export async function seedBase(prisma) {
         description: 'Treatment variant',
         configData: base.variant,
         experimentId: exp.id,
+        trafficAllocation: variantAllocation,
       },
       create: {
         id: base.idStart + 1,
@@ -241,6 +247,7 @@ export async function seedBase(prisma) {
         description: 'Treatment variant',
         configData: base.variant,
         experimentId: exp.id,
+        trafficAllocation: variantAllocation,
       },
     });
   }

--- a/prisma/seed.demo.js
+++ b/prisma/seed.demo.js
@@ -76,6 +76,7 @@ async function ensureVariants(prisma, experimentId, variantDefs) {
         description: v.description,
         configData: v.configData,
         experimentId,
+        trafficAllocation: v.trafficAllocation,
       },
       create: {
         id: v.id,
@@ -83,6 +84,7 @@ async function ensureVariants(prisma, experimentId, variantDefs) {
         description: v.description,
         configData: v.configData,
         experimentId,
+        trafficAllocation: v.trafficAllocation,
       },
     });
     created.push(row);
@@ -369,37 +371,37 @@ export async function seedDemo(prisma) {
   // Variant IDs also far away from base (base uses ~3001-3012)
   const variantMap = {
     9101: [
-      { id: 9201, name: "Control", description: "Current PDP", configData: { layout: "control" } },
-      { id: 9202, name: "Variant A", description: "Upsell widget", configData: { widget: "upsell" } },
+      { id: 9201, name: "Control", description: "Current PDP", configData: { layout: "control" }, trafficAllocation: 0 },
+      { id: 9202, name: "Variant A", description: "Upsell widget", configData: { widget: "upsell" }, trafficAllocation: 1.0 },
     ],
     9102: [
-      { id: 9211, name: "Control", description: "Current threshold copy", configData: { thresholdCopy: "standard" } },
-      { id: 9212, name: "Variant A", description: "New copy", configData: { thresholdCopy: "optimized" } },
-      { id: 9213, name: "Variant B", description: "Aggressive copy", configData: { thresholdCopy: "aggressive" } },
+      { id: 9211, name: "Control", description: "Current threshold copy", configData: { thresholdCopy: "standard" }, trafficAllocation: 0 },
+      { id: 9212, name: "Variant A", description: "New copy", configData: { thresholdCopy: "optimized" }, trafficAllocation: 0.5 },
+      { id: 9213, name: "Variant B", description: "Aggressive copy", configData: { thresholdCopy: "aggressive" }, trafficAllocation: 0.5 },
     ],
     9103: [
-      { id: 9221, name: "Control", description: "Delay 10s", configData: { delay: 10 } },
-      { id: 9222, name: "Variant A", description: "Delay 30s", configData: { delay: 30 } },
+      { id: 9221, name: "Control", description: "Delay 10s", configData: { delay: 10 }, trafficAllocation: 0 },
+      { id: 9222, name: "Variant A", description: "Delay 30s", configData: { delay: 30 }, trafficAllocation: 1.0 },
     ],
     9104: [
-      { id: 9231, name: "Control", description: "Classic drawer", configData: { drawer: "classic" } },
-      { id: 9232, name: "Variant A", description: "Modern drawer", configData: { drawer: "modern" } },
+      { id: 9231, name: "Control", description: "Classic drawer", configData: { drawer: "classic" }, trafficAllocation: 0 },
+      { id: 9232, name: "Variant A", description: "Modern drawer", configData: { drawer: "modern" }, trafficAllocation: 1.0 },
     ],
     9105: [
-      { id: 9241, name: "Control", description: "Old tiles", configData: { tiles: "old" } },
-      { id: 9242, name: "Variant A", description: "New tiles", configData: { tiles: "new" } },
+      { id: 9241, name: "Control", description: "Old tiles", configData: { tiles: "old" }, trafficAllocation: 0 },
+      { id: 9242, name: "Variant A", description: "New tiles", configData: { tiles: "new" }, trafficAllocation: 1.0 },
     ],
     9106: [
-      { id: 9251, name: "Control", description: "Old bar", configData: { bar: "old" } },
-      { id: 9252, name: "Variant A", description: "New bar", configData: { bar: "new" } },
+      { id: 9251, name: "Control", description: "Old bar", configData: { bar: "old" }, trafficAllocation: 0 },
+      { id: 9252, name: "Variant A", description: "New bar", configData: { bar: "new" }, trafficAllocation: 1.0 },
     ],
     9107: [
-      { id: 9261, name: "Control", description: "N/A", configData: { } },
-      { id: 9262, name: "Variant A", description: "N/A", configData: { } },
+      { id: 9261, name: "Control", description: "N/A", configData: { }, trafficAllocation: 0 },
+      { id: 9262, name: "Variant A", description: "N/A", configData: { }, trafficAllocation: 1.0 },
     ],
     9108: [
-      { id: 9271, name: "Control", description: "N/A", configData: { } },
-      { id: 9272, name: "Variant A", description: "N/A", configData: { } },
+      { id: 9271, name: "Control", description: "N/A", configData: { }, trafficAllocation: 0 },
+      { id: 9272, name: "Variant A", description: "N/A", configData: { }, trafficAllocation: 1.0 },
     ],
   };
 

--- a/prisma/seed.test.js
+++ b/prisma/seed.test.js
@@ -71,6 +71,7 @@ export async function seedTest(prisma) {
       description: "Control variant fixture",
       configData: { version: "control" },
       experimentId: testExperiment.id,
+      trafficAllocation: 0,
     },
     create: {
       id: 9101,
@@ -78,6 +79,7 @@ export async function seedTest(prisma) {
       description: "Control variant fixture",
       configData: { version: "control" },
       experimentId: testExperiment.id,
+      trafficAllocation: 0,
     },
   });
 
@@ -88,6 +90,7 @@ export async function seedTest(prisma) {
       description: "Treatment variant fixture",
       configData: { version: "A" },
       experimentId: testExperiment.id,
+      trafficAllocation: 1.0,
     },
     create: {
       id: 9102,
@@ -95,6 +98,7 @@ export async function seedTest(prisma) {
       description: "Treatment variant fixture",
       configData: { version: "A" },
       experimentId: testExperiment.id,
+      trafficAllocation: 1.0,
     },
   });
 


### PR DESCRIPTION
# Description
Added a per-variant traffic allocation. Previously, the traffic split (between variant and control) was built into the experiment data itself. In the pursuit of enabling multiple variants, the traffic allocation has been moved to the variant itself. 

# Migration notes
Because this field is a copy of an existing field (trafficSplit), the data for each entry needed to be copied over. The backfilling of data is as follows: 
Control variant: `trafficAllocation = 1 - trafficSplit`
All other variants `trafficAllocation = trafficSplit / count(variants)`

To make this backfilling possible, I had to generate a migration without performing it, edit the migration, and then deploy the migration. See the `prisma/migrations/20260303194226_add_variant_traffic_allocation/migration.sql` file for more on that. 

# Seeding data update
All seeding data has been updated to include the new trafficAllocation values. 

# Compatibility with previous versions
The previous traffic split fields are still in the database, and will remain until all other functions have been ported to use the new trafficAllocation pattern. Seeding data also still populates these fields.