### PR TITLE
ET-520: reports page pagination

### DIFF
--- a/app/__tests__/reportsPagination.test.jsx
+++ b/app/__tests__/reportsPagination.test.jsx
@@ -1,0 +1,111 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { useLoaderData } from 'react-router';
+import Reports from '../routes/app.reports._index';
+
+vi.mock('react-router', () => ({
+  useLoaderData: vi.fn(),
+  useFetcher: () => ({ state: 'idle', data: null, submit: vi.fn() }),
+}));
+
+vi.mock('@prisma/client', () => ({
+  ExperimentStatus: {
+    active: 'active',
+    completed: 'completed',
+    archived: 'archived',
+    paused: 'paused',
+    draft: 'draft',
+  },
+}));
+
+vi.mock('../shopify.server', () => ({
+  default: { authenticate: { admin: vi.fn() } },
+}));
+
+vi.mock('../db.server', () => ({
+  default: {
+    experiment: { findMany: vi.fn() },
+  },
+}));
+
+vi.mock('../utils/formatRuntime.js', () => ({
+  formatRuntime: () => '5 days',
+}));
+
+vi.mock('../components/DateRangePicker', () => ({
+  default: () => null,
+}));
+
+vi.mock('../components/SessionsCard', () => ({
+  default: () => null,
+}));
+
+vi.mock('../contexts/DateRangeContext', () => ({
+  useDateRange: vi.fn(() => ({ dateRange: null })),
+  formatDateForDisplay: vi.fn((d) => d),
+}));
+
+const mockExperiments = Array.from({ length: 8 }, (_, i) => ({
+  id: i + 1,
+  name: `Experiment ${i + 1}`,
+  status: 'active',
+  startDate: '2025-06-01',
+  endDate: null,
+  endCondition: 'Manual',
+  analyses: [],
+}));
+
+describe('Reports Pagination', () => {
+  beforeEach(() => {
+    useLoaderData.mockReturnValue({
+      experiments: mockExperiments,
+      sessionData: { sessions: [], total: 0 },
+      tutorialData: { viewedReportsPage: true },
+    });
+  });
+
+  it('shows only 6 experiments on the first page', () => {
+    render(<Reports />);
+    expect(screen.getByText('Experiment 1')).toBeInTheDocument();
+    expect(screen.getByText('Experiment 6')).toBeInTheDocument();
+    expect(screen.queryByText('Experiment 7')).not.toBeInTheDocument();
+  });
+
+  it('shows correct page info text on page 1', () => {
+    render(<Reports />);
+    expect(screen.getByText(/Showing 1-6 of 8/)).toBeInTheDocument();
+  });
+
+  it('Previous button is disabled on page 1', () => {
+    render(<Reports />);
+    expect(screen.getByText('Previous')).toBeDisabled();
+  });
+
+  it('navigates to page 2 when Next is clicked', () => {
+    render(<Reports />);
+    fireEvent.click(screen.getByText('Next'));
+    expect(screen.getByText('Experiment 7')).toBeInTheDocument();
+    expect(screen.getByText('Experiment 8')).toBeInTheDocument();
+    expect(screen.queryByText('Experiment 1')).not.toBeInTheDocument();
+  });
+
+  it('shows correct page info text on page 2', () => {
+    render(<Reports />);
+    fireEvent.click(screen.getByText('Next'));
+    expect(screen.getByText(/Showing 7-8 of 8/)).toBeInTheDocument();
+  });
+
+  it('Next button is disabled on the last page', () => {
+    render(<Reports />);
+    fireEvent.click(screen.getByText('Next'));
+    expect(screen.getByText('Next')).toBeDisabled();
+  });
+
+  it('can navigate back to page 1 from page 2', () => {
+    render(<Reports />);
+    fireEvent.click(screen.getByText('Next'));
+    fireEvent.click(screen.getByText('Previous'));
+    expect(screen.getByText('Experiment 1')).toBeInTheDocument();
+    expect(screen.queryByText('Experiment 7')).not.toBeInTheDocument();
+  });
+});

--- a/app/routes/app.experiments._index.jsx
+++ b/app/routes/app.experiments._index.jsx
@@ -184,6 +184,9 @@ export default function Experimentsindex() {
   const [renameValue, setRenameValue] = useState("");
   const [renameError, setRenameError] = useState(null);
 
+  //track active filter selection (all by default)
+  const [activeFilter, setActiveFilter] = useState("all");
+
   //check for errors after rename attempt
   useEffect(() => {
     if (fetcher.state === "idle" && fetcher.data?.action === "rename_error") {
@@ -304,7 +307,6 @@ export default function Experimentsindex() {
   }
 
   //TODO: restrict based on experiment goal
-  //- re
   function renderTableData(experiments) {
     const rows = [];
 
@@ -588,6 +590,17 @@ export default function Experimentsindex() {
           variant="primary"
           href="/app/experiments/new"
         >Create Experiment</s-button>
+        <div style={{ margin: "24px 0" }}>
+          <s-button commandFor="activity-filter">Filter By</s-button>
+            <s-menu id="activity-filter" accessibilityLabel="Filter by activity">
+              <s-button onClick={() => setActiveFilter("all")}>All</s-button>
+              <s-button onClick={() => setActiveFilter(ExperimentStatus.draft)}>Draft</s-button>
+              <s-button icon="gauge" onClick={() => setActiveFilter(ExperimentStatus.active)}>Active</s-button>
+              <s-button icon="check" onClick={() => setActiveFilter(ExperimentStatus.completed)}>Completed</s-button>
+              <s-button icon="pause-circle" onClick={() => setActiveFilter(ExperimentStatus.paused)}>Paused</s-button>
+              <s-button icon="order" onClick={() => setActiveFilter(ExperimentStatus.archived)}>Archived</s-button>
+            </s-menu>
+        </div>
         {/*modal for tutorial popup */}
           <s-modal
             id="tutorial-modal-settings"
@@ -639,7 +652,11 @@ export default function Experimentsindex() {
                 {/*Place Quick Access Button here */}
               </s-table-header-row>
               <s-table-body>
-                {renderTableData(experiments)}{" "}
+                {renderTableData(
+                  activeFilter === "all"
+                    ? experiments
+                    : experiments.filter((e) => e.status === activeFilter)
+                )}{" "}
                 {/* function call that returns the jsx data for table rows */}
               </s-table-body>
             </s-table>

--- a/app/routes/app.reports._index.jsx
+++ b/app/routes/app.reports._index.jsx
@@ -74,14 +74,20 @@ export default function Reports() {
   //get date range from context
   const { dateRange } = useDateRange();
 
-  //state for filtered experiments
-  const [filteredExperiments, setFilteredExperiments] = useState(
-    experiments || [],
+  //state for all experiments
+  const allActiveExperiments = (experiments || []).filter(
+    (exp) => exp.status !== ExperimentStatus.archived && exp.status !== ExperimentStatus.draft
   );
   const [filteredSessionData, setFilteredSessionData] = useState(
     sessionData || { sessions: [], total: 0 },
   );
-
+  //pagination elements
+  const [currentPage, setCurrentPage] = useState(1);
+  const itemsPerPage = 6;
+  const totalPages = Math.ceil(allActiveExperiments.length / itemsPerPage);
+  const startIndex = (currentPage - 1) * itemsPerPage;
+  const paginatedExperiments = allActiveExperiments.slice(startIndex, startIndex + itemsPerPage);
+ 
   //calculate runtime using formatRuntime utility
   const getRuntime = (experiment) => {
     return formatRuntime(
@@ -176,27 +182,8 @@ export default function Reports() {
     return rows;
   }
 
-  //filter experiments based on date range
-  //updated to exclude archived experiments
-  const filterByDateRange = (start, end) => {
-    if (!experiments) return [];
-
-    const startDate = new Date(start);
-    const endDate = new Date(end);
-
-    return experiments.filter((exp) => {
-      if (!exp.startDate) return false;
-      if (exp.status === ExperimentStatus.archived) return false;
-      const expStartDate = new Date(exp.startDate);
-      return expStartDate >= startDate && expStartDate <= endDate;
-    });
-  };
-
   //handle date range change from DateRangePicker component
   const handleDateRangeChange = (newDateRange) => {
-    setFilteredExperiments(
-      filterByDateRange(newDateRange.start, newDateRange.end),
-    );
 
     const start = new Date(newDateRange.start + "T00:00:00");
     const end = new Date(newDateRange.end + "T23:59:59");
@@ -220,7 +207,6 @@ export default function Reports() {
     }
 
     if (dateRange && experiments && sessionData) {
-      setFilteredExperiments(filterByDateRange(dateRange.start, dateRange.end));
 
       const start = new Date(dateRange.start + "T00:00:00");
       const end = new Date(dateRange.end + "T23:59:59");
@@ -339,10 +325,34 @@ export default function Reports() {
               </s-table-header>
             </s-table-header-row>
             {/* This uses the destructured filteredExperiments array */}
-            <s-table-body>{renderTableData(filteredExperiments)}</s-table-body>
+            <s-table-body>{renderTableData(paginatedExperiments)}</s-table-body>
           </s-table>
         </s-box>
       </s-section>
+      {/*pagination controls*/}
+      <>
+        <div style={{ margin: "10px 0" }}>
+          <s-paragraph>
+            <s-text>
+              Showing {startIndex + 1}-{Math.min(startIndex + itemsPerPage, allActiveExperiments.length)} of {allActiveExperiments.length} experiments
+              {totalPages > 1 && ` (Page ${currentPage} of ${totalPages})`}
+            </s-text>
+          </s-paragraph>
+        </div>
+
+        <s-button-group>
+          <s-button
+            slot="secondary-actions"
+            onClick={() => setCurrentPage(p => p - 1)}
+            disabled={currentPage === 1}
+          >Previous</s-button>
+          <s-button
+            slot="secondary-actions"
+            onClick={() => setCurrentPage(p => p + 1)}
+            disabled={currentPage === totalPages}
+          >Next</s-button>
+        </s-button-group>
+      </>
     </s-page>
   );
 }


### PR DESCRIPTION
-Reports page experiments list is now disconnected from the date picker element
-Reports page experiments list now filters out "archived" and "draft" experiments
-Reports page experiments list is now paginated
-Experiment list page experiments list can now be filtered by experiment status via dropdown (based on feedback from Nick)
<img width="795" height="192" alt="Screenshot 2026-03-03 at 5 08 11 PM" src="https://github.com/user-attachments/assets/1ff68264-63d5-42de-8b72-cec68134534e" />
