### PR TITLE
ET-523 Enable A/B/C/N multi-variant experiment testing

### DIFF
--- a/app/__tests__/createExperiment.test.js
+++ b/app/__tests__/createExperiment.test.js
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db.server", () => ({
+  default: {
+    experiment: {
+      create: vi.fn(),
+    },
+  },
+}));
+
+import db from "../db.server";
+import { createExperiment } from "../services/experiment.server";
+
+describe("createExperiment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    db.experiment.create.mockImplementation(({ data }) =>
+      Promise.resolve({ id: 1, ...data }),
+    );
+  });
+
+  it("creates Control + Variant A with correct traffic split for a single variant", async () => {
+    await createExperiment(
+      { name: "Test", description: "desc" },
+      {
+        controlSectionId: "ctrl-section",
+        variants: [{ sectionId: "var-a-section", trafficAllocation: 0.5 }],
+      },
+    );
+
+    const call = db.experiment.create.mock.calls[0][0];
+    const variants = call.data.variants.create;
+
+    expect(variants).toHaveLength(2);
+    expect(variants[0]).toMatchObject({
+      name: "Control",
+      configData: { sectionId: "ctrl-section" },
+      trafficAllocation: 0.5,
+    });
+    expect(variants[1]).toMatchObject({
+      name: "Variant A",
+      configData: { sectionId: "var-a-section" },
+      trafficAllocation: 0.5,
+    });
+  });
+
+  it("creates Control + Variant A + Variant B for two treatment variants", async () => {
+    await createExperiment(
+      { name: "ABC" },
+      {
+        controlSectionId: "ctrl",
+        variants: [
+          { sectionId: "a-sec", trafficAllocation: 0.33 },
+          { sectionId: "b-sec", trafficAllocation: 0.34 },
+        ],
+      },
+    );
+
+    const variants = db.experiment.create.mock.calls[0][0].data.variants.create;
+
+    expect(variants).toHaveLength(3);
+    expect(variants[0].name).toBe("Control");
+    expect(variants[1].name).toBe("Variant A");
+    expect(variants[2].name).toBe("Variant B");
+    expect(variants[0].trafficAllocation).toBeCloseTo(0.33, 2);
+    expect(variants[1].trafficAllocation).toBe(0.33);
+    expect(variants[2].trafficAllocation).toBe(0.34);
+  });
+
+  it("throws when treatment allocations exceed 1.0", async () => {
+    await expect(
+      createExperiment(
+        { name: "Over" },
+        {
+          variants: [
+            { sectionId: "a", trafficAllocation: 0.6 },
+            { sectionId: "b", trafficAllocation: 0.5 },
+          ],
+        },
+      ),
+    ).rejects.toThrow(/exceed 1\.0/i);
+
+    expect(db.experiment.create).not.toHaveBeenCalled();
+  });
+
+  it("sets controlSectionId to null when omitted", async () => {
+    await createExperiment(
+      { name: "No ctrl section" },
+      { variants: [{ sectionId: "a", trafficAllocation: 0.5 }] },
+    );
+
+    const variants = db.experiment.create.mock.calls[0][0].data.variants.create;
+    expect(variants[0].configData).toBeNull();
+  });
+
+  it("handles a single variant with 100% traffic (control gets 0)", async () => {
+    await createExperiment(
+      { name: "Full traffic" },
+      { variants: [{ sectionId: "a", trafficAllocation: 1.0 }] },
+    );
+
+    const variants = db.experiment.create.mock.calls[0][0].data.variants.create;
+    expect(variants[0].trafficAllocation).toBe(0);
+    expect(variants[1].trafficAllocation).toBe(1.0);
+  });
+
+  it("auto-labels variants A through C for three treatments", async () => {
+    await createExperiment(
+      { name: "Multi" },
+      {
+        variants: [
+          { sectionId: "a", trafficAllocation: 0.25 },
+          { sectionId: "b", trafficAllocation: 0.25 },
+          { sectionId: "c", trafficAllocation: 0.25 },
+        ],
+      },
+    );
+
+    const variants = db.experiment.create.mock.calls[0][0].data.variants.create;
+    expect(variants.map((v) => v.name)).toEqual([
+      "Control",
+      "Variant A",
+      "Variant B",
+      "Variant C",
+    ]);
+  });
+
+  it("defaults to no variants when options are omitted", async () => {
+    await createExperiment({ name: "Bare" });
+
+    const variants = db.experiment.create.mock.calls[0][0].data.variants.create;
+    expect(variants).toHaveLength(1);
+    expect(variants[0].name).toBe("Control");
+    expect(variants[0].trafficAllocation).toBe(1.0);
+  });
+
+  it("spreads experimentData into the create call", async () => {
+    await createExperiment(
+      { name: "E", description: "D", endCondition: "manual" },
+      { variants: [{ sectionId: "a", trafficAllocation: 0.5 }] },
+    );
+
+    const data = db.experiment.create.mock.calls[0][0].data;
+    expect(data.name).toBe("E");
+    expect(data.description).toBe("D");
+    expect(data.endCondition).toBe("manual");
+  });
+});

--- a/app/__tests__/embedScript.test.js
+++ b/app/__tests__/embedScript.test.js
@@ -1,0 +1,185 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+/**
+ * The embed script runs in a browser context and isn't exported as modules.
+ * We extract the pure logic functions and test them in isolation.
+ */
+
+// --- weightedRandomSelect (copied from embed) ---
+function weightedRandomSelect(variants) {
+  const rand = Math.random();
+  let cumulative = 0;
+  for (const v of variants) {
+    cumulative += v.trafficAllocation;
+    if (rand < cumulative) return v;
+  }
+  return variants[variants.length - 1];
+}
+
+// --- migrateOldCookies (copied from embed) ---
+function migrateOldCookies(assignments, experiments, getCookieFn) {
+  const oldControl = getCookieFn("ab-control-ids");
+  const oldVariant = getCookieFn("ab-variant-ids");
+  if (!oldControl && !oldVariant) return assignments;
+
+  const expMap = {};
+  experiments.forEach((exp) => {
+    expMap[String(exp.id)] = exp.variants;
+  });
+
+  if (oldControl) {
+    oldControl.split(",").forEach((raw) => {
+      const id = raw.trim();
+      if (!id || assignments[id] != null) return;
+      const variants = expMap[id];
+      if (!variants) return;
+      const control = variants.find((v) => v.isControl);
+      if (control) assignments[id] = control.id;
+    });
+  }
+
+  if (oldVariant) {
+    oldVariant.split(",").forEach((raw) => {
+      const id = raw.trim();
+      if (!id || assignments[id] != null) return;
+      const variants = expMap[id];
+      if (!variants) return;
+      const treatment = variants.find((v) => !v.isControl);
+      if (treatment) assignments[id] = treatment.id;
+    });
+  }
+
+  return assignments;
+}
+
+describe("weightedRandomSelect", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("selects the first variant when random is below its allocation", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.1);
+    const variants = [
+      { id: 1, name: "Control", trafficAllocation: 0.5 },
+      { id: 2, name: "Variant A", trafficAllocation: 0.5 },
+    ];
+    expect(weightedRandomSelect(variants)).toEqual(variants[0]);
+  });
+
+  it("selects the second variant when random exceeds first allocation", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.6);
+    const variants = [
+      { id: 1, name: "Control", trafficAllocation: 0.5 },
+      { id: 2, name: "Variant A", trafficAllocation: 0.5 },
+    ];
+    expect(weightedRandomSelect(variants)).toEqual(variants[1]);
+  });
+
+  it("selects the last variant when random is very close to 1.0", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.999);
+    const variants = [
+      { id: 1, name: "Control", trafficAllocation: 0.33 },
+      { id: 2, name: "Variant A", trafficAllocation: 0.33 },
+      { id: 3, name: "Variant B", trafficAllocation: 0.34 },
+    ];
+    expect(weightedRandomSelect(variants)).toEqual(variants[2]);
+  });
+
+  it("selects from three variants correctly based on allocation boundaries", () => {
+    const variants = [
+      { id: 1, name: "Control", trafficAllocation: 0.25 },
+      { id: 2, name: "Variant A", trafficAllocation: 0.25 },
+      { id: 3, name: "Variant B", trafficAllocation: 0.5 },
+    ];
+
+    vi.spyOn(Math, "random").mockReturnValue(0.24);
+    expect(weightedRandomSelect(variants).name).toBe("Control");
+
+    vi.spyOn(Math, "random").mockReturnValue(0.26);
+    expect(weightedRandomSelect(variants).name).toBe("Variant A");
+
+    vi.spyOn(Math, "random").mockReturnValue(0.51);
+    expect(weightedRandomSelect(variants).name).toBe("Variant B");
+  });
+
+  it("returns the sole variant when there's only one", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0.99);
+    const variants = [{ id: 1, name: "Control", trafficAllocation: 1.0 }];
+    expect(weightedRandomSelect(variants)).toEqual(variants[0]);
+  });
+});
+
+describe("migrateOldCookies", () => {
+  const experiments = [
+    {
+      id: 1,
+      variants: [
+        { id: 10, name: "Control", isControl: true },
+        { id: 11, name: "Variant A", isControl: false },
+      ],
+    },
+    {
+      id: 2,
+      variants: [
+        { id: 20, name: "Control", isControl: true },
+        { id: 21, name: "Variant A", isControl: false },
+      ],
+    },
+  ];
+
+  it("returns assignments unchanged when no legacy cookies exist", () => {
+    const getCookie = vi.fn().mockReturnValue(null);
+    const result = migrateOldCookies({}, experiments, getCookie);
+    expect(result).toEqual({});
+  });
+
+  it("migrates ab-control-ids into Control variant assignments", () => {
+    const getCookie = vi.fn((name) =>
+      name === "ab-control-ids" ? "1,2" : null,
+    );
+
+    const result = migrateOldCookies({}, experiments, getCookie);
+    expect(result["1"]).toBe(10);
+    expect(result["2"]).toBe(20);
+  });
+
+  it("migrates ab-variant-ids into treatment variant assignments", () => {
+    const getCookie = vi.fn((name) =>
+      name === "ab-variant-ids" ? "1" : null,
+    );
+
+    const result = migrateOldCookies({}, experiments, getCookie);
+    expect(result["1"]).toBe(11);
+  });
+
+  it("does not overwrite existing assignments during migration", () => {
+    const getCookie = vi.fn((name) =>
+      name === "ab-control-ids" ? "1" : null,
+    );
+
+    const existing = { "1": 999 };
+    const result = migrateOldCookies(existing, experiments, getCookie);
+    expect(result["1"]).toBe(999);
+  });
+
+  it("ignores experiment IDs not present in the current experiments list", () => {
+    const getCookie = vi.fn((name) =>
+      name === "ab-control-ids" ? "99" : null,
+    );
+
+    const result = migrateOldCookies({}, experiments, getCookie);
+    expect(result["99"]).toBeUndefined();
+  });
+
+  it("handles both old cookies at the same time", () => {
+    const getCookie = vi.fn((name) => {
+      if (name === "ab-control-ids") return "1";
+      if (name === "ab-variant-ids") return "2";
+      return null;
+    });
+
+    const result = migrateOldCookies({}, experiments, getCookie);
+    expect(result["1"]).toBe(10);
+    expect(result["2"]).toBe(21);
+  });
+});

--- a/app/__tests__/getFrontendExperimentsData.test.js
+++ b/app/__tests__/getFrontendExperimentsData.test.js
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../db.server", () => ({
+  default: {
+    experiment: {
+      findMany: vi.fn(),
+    },
+  },
+}));
+
+import db from "../db.server";
+import { GetFrontendExperimentsData } from "../services/experiment.server";
+
+describe("GetFrontendExperimentsData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty array when no active experiments exist", async () => {
+    db.experiment.findMany.mockResolvedValue([]);
+    const result = await GetFrontendExperimentsData();
+    expect(result).toEqual([]);
+  });
+
+  it("maps experiment data with variant-level fields for the storefront", async () => {
+    db.experiment.findMany.mockResolvedValue([
+      {
+        id: 1,
+        variants: [
+          { id: 10, name: "Control", configData: { sectionId: "sec-ctrl" }, trafficAllocation: "0.5" },
+          { id: 11, name: "Variant A", configData: { sectionId: "sec-a" }, trafficAllocation: "0.5" },
+        ],
+      },
+    ]);
+
+    const result = await GetFrontendExperimentsData();
+
+    expect(result).toEqual([
+      {
+        id: 1,
+        variants: [
+          { id: 10, name: "Control", sectionId: "sec-ctrl", trafficAllocation: 0.5, isControl: true },
+          { id: 11, name: "Variant A", sectionId: "sec-a", trafficAllocation: 0.5, isControl: false },
+        ],
+      },
+    ]);
+  });
+
+  it("sets sectionId to null when configData is missing", async () => {
+    db.experiment.findMany.mockResolvedValue([
+      {
+        id: 2,
+        variants: [
+          { id: 20, name: "Control", configData: null, trafficAllocation: "1.0" },
+        ],
+      },
+    ]);
+
+    const result = await GetFrontendExperimentsData();
+    expect(result[0].variants[0].sectionId).toBeNull();
+  });
+
+  it("converts trafficAllocation strings to numbers", async () => {
+    db.experiment.findMany.mockResolvedValue([
+      {
+        id: 3,
+        variants: [
+          { id: 30, name: "Control", configData: null, trafficAllocation: "0.33" },
+          { id: 31, name: "Variant A", configData: null, trafficAllocation: "0.67" },
+        ],
+      },
+    ]);
+
+    const result = await GetFrontendExperimentsData();
+    expect(typeof result[0].variants[0].trafficAllocation).toBe("number");
+    expect(result[0].variants[0].trafficAllocation).toBeCloseTo(0.33);
+    expect(result[0].variants[1].trafficAllocation).toBeCloseTo(0.67);
+  });
+
+  it("only queries active experiments (verified via findMany args)", async () => {
+    db.experiment.findMany.mockResolvedValue([]);
+    await GetFrontendExperimentsData();
+
+    const call = db.experiment.findMany.mock.calls[0][0];
+    expect(call.where.status).toBe("active");
+  });
+
+  it("handles multiple experiments with multiple variants", async () => {
+    db.experiment.findMany.mockResolvedValue([
+      {
+        id: 1,
+        variants: [
+          { id: 10, name: "Control", configData: { sectionId: "c1" }, trafficAllocation: "0.5" },
+          { id: 11, name: "Variant A", configData: { sectionId: "a1" }, trafficAllocation: "0.5" },
+        ],
+      },
+      {
+        id: 2,
+        variants: [
+          { id: 20, name: "Control", configData: { sectionId: "c2" }, trafficAllocation: "0.34" },
+          { id: 21, name: "Variant A", configData: { sectionId: "a2" }, trafficAllocation: "0.33" },
+          { id: 22, name: "Variant B", configData: { sectionId: "b2" }, trafficAllocation: "0.33" },
+        ],
+      },
+    ]);
+
+    const result = await GetFrontendExperimentsData();
+
+    expect(result).toHaveLength(2);
+    expect(result[0].variants).toHaveLength(2);
+    expect(result[1].variants).toHaveLength(3);
+    expect(result[1].variants[2].name).toBe("Variant B");
+    expect(result[1].variants[2].isControl).toBe(false);
+  });
+});

--- a/app/__tests__/isExperimentActive.test.js
+++ b/app/__tests__/isExperimentActive.test.js
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { ExperimentStatus } from "@prisma/client";
+
+vi.mock("../db.server", () => ({ default: {} }));
+
+import { isExperimentActive } from "../services/experiment.server";
+
+describe("isExperimentActive", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date(2026, 2, 1, 12, 0, 0));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("returns false for null/undefined experiment", () => {
+    expect(isExperimentActive(null)).toBe(false);
+    expect(isExperimentActive(undefined)).toBe(false);
+  });
+
+  it("returns false for non-active statuses", () => {
+    const base = { startDate: new Date(2026, 1, 1), endDate: null };
+    expect(isExperimentActive({ ...base, status: ExperimentStatus.draft })).toBe(false);
+    expect(isExperimentActive({ ...base, status: ExperimentStatus.paused })).toBe(false);
+    expect(isExperimentActive({ ...base, status: ExperimentStatus.completed })).toBe(false);
+    expect(isExperimentActive({ ...base, status: ExperimentStatus.archived })).toBe(false);
+  });
+
+  it("returns true for an active experiment within date range", () => {
+    expect(
+      isExperimentActive({
+        status: ExperimentStatus.active,
+        startDate: new Date(2026, 1, 1),
+        endDate: new Date(2026, 3, 1),
+      }),
+    ).toBe(true);
+  });
+
+  it("returns true for an active experiment with no end date", () => {
+    expect(
+      isExperimentActive({
+        status: ExperimentStatus.active,
+        startDate: new Date(2026, 1, 1),
+        endDate: null,
+      }),
+    ).toBe(true);
+  });
+
+  it("returns false if the check time is before the start date", () => {
+    expect(
+      isExperimentActive({
+        status: ExperimentStatus.active,
+        startDate: new Date(2026, 5, 1),
+        endDate: null,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns false if the check time is after the end date", () => {
+    expect(
+      isExperimentActive({
+        status: ExperimentStatus.active,
+        startDate: new Date(2026, 0, 1),
+        endDate: new Date(2026, 1, 1),
+      }),
+    ).toBe(false);
+  });
+
+  it("accepts a custom timeCheck argument (Date object)", () => {
+    expect(
+      isExperimentActive(
+        {
+          status: ExperimentStatus.active,
+          startDate: new Date(2026, 0, 1),
+          endDate: new Date(2026, 6, 1),
+        },
+        new Date(2026, 3, 15),
+      ),
+    ).toBe(true);
+  });
+
+  it("accepts a custom timeCheck argument (string)", () => {
+    expect(
+      isExperimentActive(
+        {
+          status: ExperimentStatus.active,
+          startDate: new Date(2026, 0, 1),
+          endDate: new Date(2026, 1, 1),
+        },
+        "2026-01-15T12:00:00.000Z",
+      ),
+    ).toBe(true);
+  });
+
+  it("returns true when startDate is null (no lower bound)", () => {
+    expect(
+      isExperimentActive({
+        status: ExperimentStatus.active,
+        startDate: null,
+        endDate: new Date(2026, 6, 1),
+      }),
+    ).toBe(true);
+  });
+});

--- a/app/__tests__/reportRecommendation.test.jsx
+++ b/app/__tests__/reportRecommendation.test.jsx
@@ -1,0 +1,342 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { useLoaderData, useFetcher, useRevalidator } from "react-router";
+
+vi.mock("react-router", () => ({
+  useLoaderData: vi.fn(),
+  useFetcher: () => ({ state: "idle", data: null, submit: vi.fn() }),
+  useRevalidator: () => ({ revalidate: vi.fn() }),
+}));
+
+vi.mock("@prisma/client", () => ({
+  ExperimentStatus: {
+    active: "active",
+    completed: "completed",
+    archived: "archived",
+    paused: "paused",
+    draft: "draft",
+  },
+  PrismaClient: vi.fn(),
+}));
+
+vi.mock("../db.server", () => ({
+  default: {},
+}));
+
+vi.mock("../shopify.server", () => ({
+  authenticate: { admin: vi.fn() },
+}));
+
+vi.mock("../contexts/DateRangeContext", () => ({
+  useDateRange: () => ({
+    dateRange: { start: "2026-01-01", end: "2026-12-31" },
+  }),
+  formatDateForDisplay: (d) => d,
+}));
+
+vi.mock("recharts", () => ({
+  LineChart: () => null,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  ResponsiveContainer: () => null,
+  ReferenceLine: () => null,
+}));
+
+vi.mock("../components/DateRangePicker", () => ({
+  default: () => null,
+}));
+
+import Report from "../routes/app.reports.$id";
+
+function buildLoaderData({
+  status = "active",
+  analysis = [],
+  analyses = [],
+  variants = [],
+}) {
+  return {
+    experiment: {
+      id: 1,
+      name: "Test Experiment",
+      status,
+      startDate: "2026-01-01T00:00:00Z",
+      sectionId: "sec-1",
+      experimentGoals: [{ goal: { name: "Purchase" } }],
+      analyses,
+      variants,
+    },
+    analysis,
+  };
+}
+
+function getBannerHeading(container) {
+  const banner = container.querySelector("s-banner[heading]");
+  return banner?.getAttribute("heading") ?? null;
+}
+
+describe("Report - recommendation logic", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows 'Collecting Data' when no Control variant exists in analysis", () => {
+    useLoaderData.mockReturnValue(
+      buildLoaderData({ analysis: [], analyses: [] }),
+    );
+    const { container } = render(<Report />);
+
+    expect(getBannerHeading(container)).toBe("Collecting Data");
+    expect(
+      screen.getByText("We need more visitors to generate a report."),
+    ).toBeTruthy();
+  });
+
+  it("finds Control by name (not index) and detects a winner", () => {
+    useLoaderData.mockReturnValue(
+      buildLoaderData({
+        status: "active",
+        analysis: [
+          {
+            id: 2,
+            variantName: "Variant A",
+            conversionRate: 0.15,
+            probabilityOfBeingBest: 0.9,
+            expectedLoss: 0.001,
+            totalConversions: 80,
+            totalUsers: 500,
+            improvement: 50,
+          },
+          {
+            id: 1,
+            variantName: "Control",
+            conversionRate: 0.10,
+            probabilityOfBeingBest: 0.1,
+            expectedLoss: 0.01,
+            totalConversions: 50,
+            totalUsers: 500,
+            improvement: 0,
+          },
+        ],
+        analyses: [],
+        variants: [
+          { id: 1, name: "Control" },
+          { id: 2, name: "Variant A" },
+        ],
+      }),
+    );
+
+    const { container } = render(<Report />);
+    expect(getBannerHeading(container)).toBe("Deployable!");
+    expect(screen.getByText(/Variant A.*is winning/)).toBeTruthy();
+  });
+
+  it("detects multiple winners", () => {
+    useLoaderData.mockReturnValue(
+      buildLoaderData({
+        status: "active",
+        analysis: [
+          {
+            id: 1,
+            variantName: "Control",
+            conversionRate: 0.05,
+            probabilityOfBeingBest: 0.05,
+            expectedLoss: 0.05,
+            totalConversions: 25,
+            totalUsers: 500,
+            improvement: 0,
+          },
+          {
+            id: 2,
+            variantName: "Variant A",
+            conversionRate: 0.12,
+            probabilityOfBeingBest: 0.85,
+            expectedLoss: 0.001,
+            totalConversions: 60,
+            totalUsers: 500,
+            improvement: 40,
+          },
+          {
+            id: 3,
+            variantName: "Variant B",
+            conversionRate: 0.13,
+            probabilityOfBeingBest: 0.82,
+            expectedLoss: 0.001,
+            totalConversions: 65,
+            totalUsers: 500,
+            improvement: 45,
+          },
+        ],
+        analyses: [],
+        variants: [
+          { id: 1, name: "Control" },
+          { id: 2, name: "Variant A" },
+          { id: 3, name: "Variant B" },
+        ],
+      }),
+    );
+
+    const { container } = render(<Report />);
+    expect(getBannerHeading(container)).toBe(
+      "Multiple Variants are Deployable!",
+    );
+    expect(
+      screen.getByText(/Variant A and Variant B are winning/),
+    ).toBeTruthy();
+  });
+
+  it("shows 'Continue Testing' when no clear winner yet (active)", () => {
+    useLoaderData.mockReturnValue(
+      buildLoaderData({
+        status: "active",
+        analysis: [
+          {
+            id: 1,
+            variantName: "Control",
+            conversionRate: 0.10,
+            probabilityOfBeingBest: 0.55,
+            expectedLoss: 0.01,
+            totalConversions: 50,
+            totalUsers: 500,
+            improvement: 0,
+          },
+          {
+            id: 2,
+            variantName: "Variant A",
+            conversionRate: 0.11,
+            probabilityOfBeingBest: 0.45,
+            expectedLoss: 0.02,
+            totalConversions: 55,
+            totalUsers: 500,
+            improvement: 10,
+          },
+        ],
+        analyses: [],
+        variants: [
+          { id: 1, name: "Control" },
+          { id: 2, name: "Variant A" },
+        ],
+      }),
+    );
+
+    const { container } = render(<Report />);
+    expect(getBannerHeading(container)).toBe("Continue Testing");
+    expect(screen.getByText("No clear winner yet.")).toBeTruthy();
+  });
+
+  it("shows 'Continue Testing' when a variant peaked historically but no current winner", () => {
+    useLoaderData.mockReturnValue(
+      buildLoaderData({
+        status: "active",
+        analysis: [
+          {
+            id: 1,
+            variantName: "Control",
+            conversionRate: 0.10,
+            probabilityOfBeingBest: 0.55,
+            expectedLoss: 0.01,
+            totalConversions: 50,
+            totalUsers: 500,
+            improvement: 0,
+          },
+          {
+            id: 2,
+            variantName: "Variant A",
+            conversionRate: 0.11,
+            probabilityOfBeingBest: 0.45,
+            expectedLoss: 0.02,
+            totalConversions: 55,
+            totalUsers: 500,
+            improvement: 10,
+          },
+        ],
+        analyses: [
+          {
+            probabilityOfBeingBest: 0.85,
+            variant: { name: "Variant A" },
+            calculatedWhen: new Date("2026-01-05"),
+          },
+        ],
+        variants: [
+          { id: 1, name: "Control" },
+          { id: 2, name: "Variant A" },
+        ],
+      }),
+    );
+
+    const { container } = render(<Report />);
+    expect(getBannerHeading(container)).toBe("Continue Testing");
+    expect(
+      screen.getByText(/Variant A hit 80% previously/),
+    ).toBeTruthy();
+  });
+
+  it("shows 'Inconclusive' when completed with no winner", () => {
+    useLoaderData.mockReturnValue(
+      buildLoaderData({
+        status: "completed",
+        analysis: [
+          {
+            id: 1,
+            variantName: "Control",
+            conversionRate: 0.10,
+            probabilityOfBeingBest: 0.55,
+            expectedLoss: 0.01,
+            totalConversions: 50,
+            totalUsers: 500,
+            improvement: 0,
+          },
+          {
+            id: 2,
+            variantName: "Variant A",
+            conversionRate: 0.11,
+            probabilityOfBeingBest: 0.45,
+            expectedLoss: 0.02,
+            totalConversions: 55,
+            totalUsers: 500,
+            improvement: 10,
+          },
+        ],
+        analyses: [],
+        variants: [
+          { id: 1, name: "Control" },
+          { id: 2, name: "Variant A" },
+        ],
+      }),
+    );
+
+    const { container } = render(<Report />);
+    expect(getBannerHeading(container)).toBe("Inconclusive");
+    expect(screen.getByText("No clear winner was found.")).toBeTruthy();
+  });
+
+  it("shows 'Draft' for non-active experiments", () => {
+    useLoaderData.mockReturnValue(
+      buildLoaderData({
+        status: "draft",
+        analysis: [
+          {
+            id: 1,
+            variantName: "Control",
+            conversionRate: 0.10,
+            probabilityOfBeingBest: 0.5,
+            expectedLoss: 0.01,
+            totalConversions: 0,
+            totalUsers: 0,
+            improvement: 0,
+          },
+        ],
+        analyses: [],
+        variants: [{ id: 1, name: "Control" }],
+      }),
+    );
+
+    const { container } = render(<Report />);
+    expect(getBannerHeading(container)).toBe("Draft");
+    expect(screen.getByText("Experiment is not active.")).toBeTruthy();
+  });
+});

--- a/app/__tests__/reportTable.test.jsx
+++ b/app/__tests__/reportTable.test.jsx
@@ -1,0 +1,152 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { useLoaderData } from "react-router";
+
+vi.mock("react-router", () => ({
+  useLoaderData: vi.fn(),
+  useFetcher: () => ({ state: "idle", data: null, submit: vi.fn() }),
+  useRevalidator: () => ({ revalidate: vi.fn() }),
+}));
+
+vi.mock("@prisma/client", () => ({
+  ExperimentStatus: {
+    active: "active",
+    completed: "completed",
+    archived: "archived",
+    paused: "paused",
+    draft: "draft",
+  },
+  PrismaClient: vi.fn(),
+}));
+
+vi.mock("../db.server", () => ({
+  default: {},
+}));
+
+vi.mock("../shopify.server", () => ({
+  authenticate: { admin: vi.fn() },
+}));
+
+vi.mock("../contexts/DateRangeContext", () => ({
+  useDateRange: () => ({
+    dateRange: { start: "2026-01-01", end: "2026-12-31" },
+  }),
+  formatDateForDisplay: (d) => d,
+}));
+
+vi.mock("recharts", () => ({
+  LineChart: () => null,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  ResponsiveContainer: () => null,
+  ReferenceLine: () => null,
+}));
+
+vi.mock("../components/DateRangePicker", () => ({
+  default: () => null,
+}));
+
+import Report from "../routes/app.reports.$id";
+
+function makeAnalysisRow(overrides) {
+  return {
+    id: 1,
+    variantName: "Control",
+    conversionRate: 0.10,
+    probabilityOfBeingBest: 0.5,
+    expectedLoss: 0.01,
+    totalConversions: 50,
+    totalUsers: 500,
+    improvement: 0,
+    ...overrides,
+  };
+}
+
+function buildLoaderData(analysis) {
+  return {
+    experiment: {
+      id: 1,
+      name: "Table Test",
+      status: "active",
+      startDate: "2026-01-01T00:00:00Z",
+      sectionId: "sec-1",
+      experimentGoals: [{ goal: { name: "Purchase" } }],
+      analyses: [],
+      variants: analysis.map((a) => ({ id: a.id, name: a.variantName })),
+    },
+    analysis,
+  };
+}
+
+describe("Report - renderTableData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows 'Baseline' for the Control row improvement regardless of its position", () => {
+    const analysis = [
+      makeAnalysisRow({ id: 2, variantName: "Variant A", improvement: 25, conversionRate: 0.15, probabilityOfBeingBest: 0.6 }),
+      makeAnalysisRow({ id: 1, variantName: "Control", improvement: 0, conversionRate: 0.10, probabilityOfBeingBest: 0.4 }),
+    ];
+
+    useLoaderData.mockReturnValue(buildLoaderData(analysis));
+    render(<Report />);
+
+    expect(screen.getByText("Baseline")).toBeTruthy();
+  });
+
+  it("shows formatted improvement for non-Control variants", () => {
+    const analysis = [
+      makeAnalysisRow({ id: 1, variantName: "Control" }),
+      makeAnalysisRow({ id: 2, variantName: "Variant A", improvement: 25, conversionRate: 0.15, probabilityOfBeingBest: 0.7 }),
+    ];
+
+    useLoaderData.mockReturnValue(buildLoaderData(analysis));
+    render(<Report />);
+
+    expect(screen.queryByText("Baseline")).toBeTruthy();
+    expect(screen.getByText("25.00%")).toBeTruthy();
+  });
+
+  it("renders all variant rows including A, B, C", () => {
+    const analysis = [
+      makeAnalysisRow({ id: 1, variantName: "Control" }),
+      makeAnalysisRow({ id: 2, variantName: "Variant A", improvement: 10 }),
+      makeAnalysisRow({ id: 3, variantName: "Variant B", improvement: 20 }),
+      makeAnalysisRow({ id: 4, variantName: "Variant C", improvement: 30 }),
+    ];
+
+    useLoaderData.mockReturnValue(buildLoaderData(analysis));
+    render(<Report />);
+
+    expect(screen.getByText("Control")).toBeTruthy();
+    expect(screen.getByText("Variant A")).toBeTruthy();
+    expect(screen.getByText("Variant B")).toBeTruthy();
+    expect(screen.getByText("Variant C")).toBeTruthy();
+  });
+
+  it("renders nothing when analysis is empty", () => {
+    useLoaderData.mockReturnValue(buildLoaderData([]));
+    const { container } = render(<Report />);
+    const tableBody = container.querySelector("s-table-body");
+    expect(tableBody?.children.length ?? 0).toBe(0);
+  });
+
+  it("displays conversions/users for each row", () => {
+    const analysis = [
+      makeAnalysisRow({ id: 1, variantName: "Control", totalConversions: 42, totalUsers: 300 }),
+      makeAnalysisRow({ id: 2, variantName: "Variant A", totalConversions: 67, totalUsers: 300, improvement: 15 }),
+    ];
+
+    useLoaderData.mockReturnValue(buildLoaderData(analysis));
+    render(<Report />);
+
+    expect(screen.getByText("42 / 300")).toBeTruthy();
+    expect(screen.getByText("67 / 300")).toBeTruthy();
+  });
+});

--- a/app/routes/api.experiments.jsx
+++ b/app/routes/api.experiments.jsx
@@ -25,7 +25,7 @@ export const loader = async ({ request }) => {
       request.headers.get("Access-Control-Request-Headers") ?? "";
     const experiments = await GetFrontendExperimentsData();
 
-    if (!experiments) {
+    if (!experiments || experiments.length === 0) {
       return new Response(
         JSON.stringify({
           error: "No active experiments were found",

--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -463,17 +463,19 @@ export default function Index() {
                     />
                     <Tooltip />
                     <Legend />
-                    <Line
-                      type="monotone"
-                      dataKey={experiment.variants[0]?.name ?? "Baseline"}
-                      stroke="#8884d8"
-                      activeDot={{ r: 8 }}
-                    />
-                    <Line
-                      type="monotone"
-                      dataKey={experiment.variants[1]?.name ?? "Variant B"}
-                      stroke="#82ca9d"
-                    />
+                    {experiment.variants.map((v, index) => {
+                      const colors = ["#5C6AC4", "#9C6ADE", "#00A0AC", "#FFC447"];
+                      return (
+                        <Line
+                          key={v.id}
+                          type="monotone"
+                          dataKey={v.name}
+                          stroke={colors[index % colors.length]}
+                          activeDot={{ r: 8 }}
+                          dot={false}
+                        />
+                      );
+                    })}
                   </LineChart>
                 </ResponsiveContainer>
               ) : (

--- a/app/routes/app.experiments.$id.jsx
+++ b/app/routes/app.experiments.$id.jsx
@@ -44,7 +44,7 @@ export const loader = async ({ params, request }) => {
           goal: true,
         },
       },
-      variants: false, // we only need to know if variants exist and the first variant's sectionId, so we can skip fetching all variant details
+      variants: true,
     },
   });
 
@@ -85,15 +85,30 @@ export const loader = async ({ params, request }) => {
     ? goalNameToKey[primaryGoal.goal.name] || "completedCheckout"
     : "completedCheckout";
 
+  const controlVariant = experiment.variants.find((v) => v.name === "Control");
+  const treatmentVariants = experiment.variants
+    .filter((v) => v.name !== "Control")
+    .sort((a, b) => a.id - b.id)
+    .map((v) => ({
+      sectionId: v.configData?.sectionId || "",
+      trafficAllocation: Math.round(Number(v.trafficAllocation) * 100),
+    }));
+
+  if (treatmentVariants.length === 0) {
+    treatmentVariants.push({
+      sectionId: experiment.sectionId || "",
+      trafficAllocation: Math.round(Number(experiment.trafficSplit) * 100),
+    });
+  }
+
   return {
     experiment: {
       id: experiment.id,
       status: experiment.status,
       name: experiment.name,
       description: experiment.description,
-      sectionId: experiment.sectionId,
-      controlSectionId: experiment.controlSectionId,
-      trafficSplit: experiment.trafficSplit * 100, // Convert back to percentage
+      controlSectionId: controlVariant?.configData?.sectionId || experiment.controlSectionId || "",
+      variants: treatmentVariants,
       startDate: formatDate(experiment.startDate),
       startTime: formatTime(experiment.startDate),
       endDate: formatDate(experiment.endDate),
@@ -103,11 +118,6 @@ export const loader = async ({ params, request }) => {
       probabilityToBeBest: experiment.probabilityToBeBest,
       duration: experiment.duration,
       timeUnit: experiment.timeUnit,
-      hasVariants: experiment.variants && experiment.variants.length > 0,
-      variantSectionId:
-        experiment.variants && experiment.variants.length > 0
-          ? experiment.variants[0].sectionId
-          : "",
     },
   };
 };
@@ -244,19 +254,28 @@ export const action = async ({ request, params }) => {
   /* ====================================================================================================
    Read Form Fields
    ==================================================================================================== */
-  // Get POST request form data & create experiment
+  // Get POST request form data & update experiment
   const name = (formData.get("name") || "").trim();
   const description = (formData.get("description") || "").trim();
-  const sectionId = (formData.get("sectionId") || "").trim();
   const controlSectionId = (formData.get("controlSectionId") || "").trim();
-  const variantSectionId = (formData.get("variantSectionId") || "").trim();
-  const variantEnabled = formData.get("variant") === "true";
   const goalValue = (formData.get("goal") || "").trim();
   const endCondition = (formData.get("endCondition") || "").trim();
-  const trafficSplitStr = (formData.get("trafficSplit") || "50").trim(); // Default to "0"
   const probabilityToBeBestStr = (formData.get("probabilityToBeBest") || "").trim();
   const durationStr = (formData.get("duration") || "").trim();
   const timeUnitValue = (formData.get("timeUnit") || "").trim();
+
+  let variantInputs;
+  try {
+    variantInputs = JSON.parse(formData.get("variantsJSON") || "[]");
+  } catch {
+    variantInputs = [];
+  }
+  const sectionId = (variantInputs[0]?.sectionId || "").trim();
+  const totalTrafficPct = variantInputs.reduce(
+    (sum, v) => sum + (v.trafficAllocation || 0),
+    0,
+  );
+  const trafficSplitStr = String(totalTrafficPct);
 
   // Date/Time Fields (accepts both client-side UTC strings or separate date/time fields)
   const startDateUTC = (formData.get("startDateUTC") || "").trim();
@@ -274,6 +293,12 @@ export const action = async ({ request, params }) => {
 
   if (!name) errors.name = "Name is required";
   if (!description) errors.description = "Description is required";
+  variantInputs.forEach((v, i) => {
+    if (!(v.sectionId || "").trim()) {
+      errors[`variant_${i}_sectionId`] =
+        `Variant ${String.fromCharCode(65 + i)} Section ID is required`;
+    }
+  });
   if (!startDateStr && !startDateUTC)
     errors.startDate = "Start Date is required";
   if (endCondition === "stableSuccessProbability" && !probabilityToBeBestStr)
@@ -414,6 +439,40 @@ export const action = async ({ request, params }) => {
     updateData.trafficSplit = parseFloat(trafficSplitStr) / 100.0;
   }
 
+  // Build variant operations (draft only - recreate all variants)
+  let variantOps = null;
+  if (editStructure) {
+    const VARIANT_LABELS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    const treatmentVariants = variantInputs.map((v) => ({
+      sectionId: (v.sectionId || "").trim(),
+      trafficAllocation: (v.trafficAllocation || 0) / 100.0,
+    }));
+    const treatmentAllocation = treatmentVariants.reduce(
+      (sum, v) => sum + v.trafficAllocation,
+      0,
+    );
+    const controlAllocation = Math.max(0, 1.0 - treatmentAllocation);
+
+    const variantCreates = [];
+    variantCreates.push({
+      name: "Control",
+      configData: controlSectionId ? { sectionId: controlSectionId } : null,
+      trafficAllocation: controlAllocation,
+    });
+    treatmentVariants.forEach((v, i) => {
+      variantCreates.push({
+        name: `Variant ${VARIANT_LABELS[i]}`,
+        configData: v.sectionId ? { sectionId: v.sectionId } : null,
+        trafficAllocation: v.trafficAllocation,
+      });
+    });
+
+    variantOps = {
+      deleteMany: {},
+      create: variantCreates,
+    };
+  }
+
   /* ====================================================================================================
    Goal Ops for Draft
    ==================================================================================================== */
@@ -453,6 +512,7 @@ export const action = async ({ request, params }) => {
       data: {
         ...updateData,
         ...(goalOps ? { experimentGoals: goalOps } : {}),
+        ...(variantOps ? { variants: variantOps } : {}),
       },
     });
 
@@ -500,22 +560,22 @@ export default function EditExperiment() {
   const [nameError, setNameError] = useState(null);
   const [description, setDescription] = useState("");
   const [emptyDescriptionError, setDescriptionError] = useState(null);
-  const [sectionId, setSectionId] = useState("");
+  const MAX_VARIANTS = 4;
+  const VARIANT_LABELS = ["A", "B", "C", "D"];
+
+  const [variants, setVariants] = useState([
+    { sectionId: "", trafficAllocation: 50 },
+  ]);
+  const [variantSectionErrors, setVariantSectionErrors] = useState([null]);
+  const [addControlSection, setAddControlSection] = useState(false);
   const [controlSectionId, setControlSectionId] = useState("");
-  const [emptySectionIdError, setSectionIdError] = useState(null);
-  const [emptySectionIdVariantError, setSectionIdVariantError] = useState(null);
   const [emptyStartDateError, setEmptyStartDateError] = useState(null);
   const [emptyEndDateError, setEmptyEndDateError] = useState(null);
   const [endDate, setEndDate] = useState("");
   const [endDateError, setEndDateError] = useState("");
-  const [experimentChance, setExperimentChance] = useState(50);
   const [endCondition, setEndCondition] = useState("manual");
   const [goalSelected, setGoalSelected] = useState("completedCheckout");
   const [customerSegment, setCustomerSegment] = useState("allSegments");
-  const [variant, setVariant] = useState(false);
-  const [variantDisplay, setVariantDisplay] = useState("none");
-  const [variantSectionId, setVariantSectionId] = useState("");
-  const [variantExperimentChance, setVariantExperimentChance] = useState(50);
   const [startDate, setStartDate] = useState("");
   const [startDateError, setStartDateError] = useState("");
   const [startTime, setStartTime] = useState("");
@@ -584,9 +644,10 @@ export default function EditExperiment() {
       const exp = loaderData.experiment;
       setName(exp.name);
       setDescription(exp.description);
-      setSectionId(exp.sectionId);
-      setControlSectionId(exp.controlSectionId);
-      setExperimentChance(exp.trafficSplit);
+      setControlSectionId(exp.controlSectionId || "");
+      if (exp.controlSectionId) {
+        setAddControlSection(true);
+      }
       setStartDate(exp.startDate);
       setStartTime(exp.startTime);
       setEndDate(exp.endDate);
@@ -597,10 +658,9 @@ export default function EditExperiment() {
       setDuration(exp.duration || "");
       setTimeUnit(exp.timeUnit || "days");
 
-      if (exp.hasVariants) {
-        setVariant(true);
-        setVariantDisplay("auto");
-        setVariantSectionId(exp.variantSectionId);
+      if (exp.variants && exp.variants.length > 0) {
+        setVariants(exp.variants);
+        setVariantSectionErrors(exp.variants.map(() => null));
       }
     }
   }, [loaderData]);
@@ -616,6 +676,11 @@ export default function EditExperiment() {
 
   const errors = fetcher.data?.errors || {}; // looks for error data, if empty instantiate errors as empty object
 
+  const controlAllocation = Math.max(
+    0,
+    100 - variants.reduce((sum, v) => sum + v.trafficAllocation, 0),
+  );
+
   //Check if there were any errors on the form
   const hasClientErrors = renameOnlyMode ? (!!nameError || !!errors.name) :
     (
@@ -623,10 +688,7 @@ export default function EditExperiment() {
       !!errors.name ||
       !!emptyDescriptionError ||
       !!errors.description ||
-      !!emptySectionIdError ||
-      !!errors.sectionId ||
-      (variant && !!emptySectionIdVariantError) ||
-      (variant && !!errors.variantSectionId) ||
+      variantSectionErrors.some((e) => !!e) ||
       !!probabilityToBeBestError ||
       !!errors.probabilityToBeBest ||
       !!durationError ||
@@ -644,7 +706,6 @@ export default function EditExperiment() {
   const handleExperimentEdit = async () => {
     const experimentData = renameOnlyMode ? { name: name } : (() => {
 
-      // creates data object for all current state variables
       const startDateUTC = startDate
         ? localDateTimeToISOString(startDate, startTime)
         : "";
@@ -656,18 +717,15 @@ export default function EditExperiment() {
       return {
         name: name,
         description: description,
-        sectionId: sectionId,
         controlSectionId: controlSectionId,
-        variantSectionId: variantSectionId,
-        variant: String(variant),
-        goal: goalSelected, // holds the "view-page" value
-        endCondition: endCondition, // holds "Manual", "End Data"
-        startDateUTC: startDateUTC, // The date string from s-date-field
-        endDateUTC: endDateUTC, // The date string from s-date-field
-        endDate: endDate, // The date string from s-date-field
-        trafficSplit: experimentChance, // 0-100 value
-        probabilityToBeBest: probabilityToBeBest, //holds validated value 51-100
-        duration: duration, //length of time for experiment run
+        variantsJSON: JSON.stringify(variants),
+        goal: goalSelected,
+        endCondition: endCondition,
+        startDateUTC: startDateUTC,
+        endDateUTC: endDateUTC,
+        endDate: endDate,
+        probabilityToBeBest: probabilityToBeBest,
+        duration: duration,
         timeUnit: timeUnit,
       };
     })();
@@ -696,20 +754,20 @@ export default function EditExperiment() {
     }
   };
 
-  const handleSectionIdBlur = () => {
-    if (!sectionId.trim()) {
-      setSectionIdError("Section ID is a required field");
-    } else {
-      setSectionIdError(null); //clears error once user fixes
-    }
+  const updateVariant = (index, field, value) => {
+    setVariants((prev) =>
+      prev.map((v, i) => (i === index ? { ...v, [field]: value } : v)),
+    );
   };
 
-  const handleSectionIdVariantBlur = () => {
-    if (variant && !variantSectionId.trim()) {
-      setSectionIdVariantError("Section ID is a required field");
-    } else {
-      setSectionIdVariantError(null); //clears error once user fixes
-    }
+  const handleVariantSectionIdBlur = (index) => {
+    setVariantSectionErrors((prev) => {
+      const next = [...prev];
+      next[index] = !variants[index].sectionId.trim()
+        ? "Section ID is a required field"
+        : null;
+      return next;
+    });
   };
 
   const handleStartDateBlur = () => {
@@ -898,17 +956,25 @@ export default function EditExperiment() {
     setEndTimeError(errors.endTimeError);
   };
 
-  const handleVariant = () => {
-    setVariant(true);
-    setVariantDisplay("auto");
-    setVariantExperimentChance(50);
+  const handleAddVariant = () => {
+    if (variants.length >= MAX_VARIANTS) return;
+    const newCount = variants.length + 1;
+    const evenSplit = Math.floor(100 / (newCount + 1));
+    setVariants((prev) => [
+      ...prev.map((v) => ({ ...v, trafficAllocation: evenSplit })),
+      { sectionId: "", trafficAllocation: evenSplit },
+    ]);
+    setVariantSectionErrors((prev) => [...prev, null]);
   };
 
-  const handleVariantUndo = () => {
-    setVariant(false);
-    setVariantDisplay("none");
-    setVariantSectionId("");
-    setVariantExperimentChance();
+  const handleRemoveVariant = () => {
+    if (variants.length <= 1) return;
+    const newCount = variants.length - 1;
+    const evenSplit = Math.floor(100 / (newCount + 1));
+    setVariants((prev) =>
+      prev.slice(0, -1).map((v) => ({ ...v, trafficAllocation: evenSplit })),
+    );
+    setVariantSectionErrors((prev) => prev.slice(0, -1));
   };
 
   const descriptionError = errors.description;
@@ -925,16 +991,6 @@ export default function EditExperiment() {
     allSegments: "All Segments",
     desktopVisitors: "Desktop Visitors",
     mobileVisitors: "Mobile Visitors",
-  };
-
-  const variationMap = {
-    false: "Single Variation",
-    true: "Multiple Variations",
-  };
-
-  const variantMap = {
-    false: "none",
-    true: "auto",
   };
 
   // derive current badge info and icon from selected goal
@@ -978,32 +1034,32 @@ export default function EditExperiment() {
         <s-section heading={name ? name : "no experiment name set"}>
           <s-stack gap="small">
             <s-badge icon={icon}>{label}</s-badge>
-            <s-badge
-              tone={sectionId ? "" : "warning"}
-              icon={sectionId ? "code" : "alert-circle"}
-            >
-              {sectionId || "Section not selected"}
-            </s-badge>
-            <s-stack display={variantDisplay}>
+            {variants.map((v, i) => (
               <s-badge
-                tone={variantSectionId ? "" : "warning"}
-                icon={variantSectionId ? "code" : "alert-circle"}
+                key={i}
+                tone={v.sectionId ? "" : "warning"}
+                icon={v.sectionId ? "code" : "alert-circle"}
               >
-                {variantSectionId || "Section not selected"}
+                Variant {VARIANT_LABELS[i]}:{" "}
+                {v.sectionId || "Section not selected"}
               </s-badge>
-            </s-stack>
+            ))}
 
             <s-text font-weight="heavy">Experiment Details</s-text>
 
-            {/* DYNAMIC BULLET LIST */}
             <s-text>• {customerSegments}</s-text>
-            <s-text>• {variationMap[variant] || "—"}</s-text>
-            <s-text>• {experimentChance}% Chance to show Variant 1</s-text>
-            <s-stack display={variantDisplay}>
-              <s-text>
-                • {variantExperimentChance}% Chance to show Variant 2
+            <s-text>
+              •{" "}
+              {variants.length === 1
+                ? "Single Variation"
+                : `${variants.length} Variations`}
+            </s-text>
+            {variants.map((v, i) => (
+              <s-text key={i}>
+                • {v.trafficAllocation}% Variant {VARIANT_LABELS[i]}
               </s-text>
-            </s-stack>
+            ))}
+            <s-text>• {controlAllocation}% Control</s-text>
             <s-text>
               • Active from{" "}
               {startDate
@@ -1201,132 +1257,104 @@ export default function EditExperiment() {
       <s-section heading="Experiment Details">
         <s-form>
           <s-stack direction="block" gap="base" paddingBlock="base">
-            <s-stack direction="block" gap="small">
-              <s-stack display={variantDisplay}>
-                <s-heading>Variant 1</s-heading>
-              </s-stack>
-              {/*Custom Label Row (SectionID + help link)*/}
-              <s-link href="#" target="_blank">
-                How do I find my section?
-              </s-link>
-              <s-text-field
-                placeholder="shopify-section-sections--25210977943842__header"
-                value={sectionId}
-                label="Section ID to be tested"
-                required
-                disabled={isLocked || !editStructure}
-                onFocus={() => {
-                  setSectionIdError(null);
-                  if (fetcher.data?.errors?.sectionId) {
-                    //clear server-side errors by resetting fetcher data
-                    fetcher.data = {
-                      ...fetcher.data,
-                      errors: { ...fetcher.data.errors, sectionId: undefined },
-                    };
-                  }
-                }}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  setSectionId(v);
-                  if (emptySectionIdError && v.trim()) setSectionIdError(null);
-                }}
-                onBlur={handleSectionIdBlur}
-                error={errors.sectionId || emptySectionIdError}
-                details="The associated Shopify section ID to be tested. Must be visible on production site"
-              />
-            </s-stack>
-
-            {/* There is no error checking for this section intentionally. If a user supplies a control ID, that's great */}
-            {/* But, you don't need it and may not want it, so it can be blank. */}
-            <s-text-field
-              placeholder="shopify-section-sections--25210972849284__header"
-              value={controlSectionId}
-              label="Optional: Control Section ID"
-              required
-              disabled={isLocked || !editStructure}
-              onChange={(e) => {
-                const v = e.target.value;
-                setControlSectionId(v);
-              }}
-              details="The control section ID that will be replaced by the variant for users who are in the experiment. Must be visible on production site"
-            />
-
-            <s-number-field
-              label="Chance to show experiment"
-              value={experimentChance}
-              inputMode="numeric"
-              disabled={isLocked || !editStructure}
-              onChange={(e) => {
-                const value = Math.max(
-                  0,
-                  Math.min(100, Number(e.target.value)),
-                );
-                setExperimentChance(value);
-              }}
-              min={0}
-              max={100}
-              step={1}
-              suffix="%"
-            />
-
-            {/* Variant 2 fields */}
-            <s-stack display={variantDisplay} paddingBlock="base">
-              <s-heading>Variant 2</s-heading>
-
-              <s-stack direction="block" gap="small" paddingBlock="base">
-                {/*Custom Label Row (SectionID + help link)*/}
+            {variants.map((variant, i) => (
+              <s-stack
+                key={i}
+                direction="block"
+                gap="small"
+                paddingBlock={i > 0 ? "base" : undefined}
+              >
+                <s-heading>Variant {VARIANT_LABELS[i]}</s-heading>
                 <s-link href="#" target="_blank">
                   How do I find my section?
                 </s-link>
                 <s-text-field
                   placeholder="shopify-section-sections--25210977943842__header"
-                  value={variantSectionId}
+                  value={variant.sectionId}
                   label="Section ID to be tested"
                   required
                   disabled={isLocked || !editStructure}
                   onFocus={() => {
-                    setSectionIdVariantError(null);
-                    if (fetcher.data?.errors?.variantSectionId) {
-                      //clear server-side errors by resetting fetcher data
+                    setVariantSectionErrors((prev) => {
+                      const next = [...prev];
+                      next[i] = null;
+                      return next;
+                    });
+                    if (fetcher.data?.errors?.[`variant_${i}_sectionId`]) {
                       fetcher.data = {
                         ...fetcher.data,
                         errors: {
                           ...fetcher.data.errors,
-                          variantSectionId: undefined,
+                          [`variant_${i}_sectionId`]: undefined,
                         },
                       };
                     }
                   }}
                   onChange={(e) => {
-                    const v = e.target.value;
-                    setVariantSectionId(v);
-                    if (emptySectionIdVariantError && v.trim())
-                      setSectionIdVariantError(null);
+                    const val = e.target.value;
+                    updateVariant(i, "sectionId", val);
+                    if (variantSectionErrors[i] && val.trim()) {
+                      setVariantSectionErrors((prev) => {
+                        const next = [...prev];
+                        next[i] = null;
+                        return next;
+                      });
+                    }
                   }}
-                  onBlur={handleSectionIdVariantBlur}
-                  error={errors.variantSectionId || emptySectionIdVariantError}
+                  onBlur={() => handleVariantSectionIdBlur(i)}
+                  error={
+                    variantSectionErrors[i] || errors[`variant_${i}_sectionId`]
+                  }
                   details="The associated Shopify section ID to be tested. Must be visible on production site"
                 />
+                <s-number-field
+                  label={`Traffic allocation for Variant ${VARIANT_LABELS[i]}`}
+                  value={variant.trafficAllocation}
+                  inputMode="numeric"
+                  disabled={isLocked || !editStructure}
+                  onChange={(e) => {
+                    const othersTotal = variants.reduce(
+                      (sum, v, idx) => (idx !== i ? sum + v.trafficAllocation : sum),
+                      0,
+                    );
+                    const maxAllowed = 100 - othersTotal;
+                    const value = Math.max(0, Math.min(maxAllowed, Number(e.target.value)));
+                    updateVariant(i, "trafficAllocation", value);
+                  }}
+                  min={0}
+                  max={100 - variants.reduce((sum, v, idx) => (idx !== i ? sum + v.trafficAllocation : sum), 0)}
+                  step={1}
+                  suffix="%"
+                />
               </s-stack>
+            ))}
 
-              <s-number-field
-                label="Chance to show experiment"
-                value={variantExperimentChance}
-                inputMode="numeric"
+            <s-checkbox
+              label="Add a control section ID"
+              checked={addControlSection}
+              disabled={isLocked || !editStructure}
+              details="If you want the variant section to replace the control section, add a control section ID"
+              onChange={() => {
+                setAddControlSection(!addControlSection);
+              }}
+            />
+            {addControlSection && (
+              <s-text-field
+                placeholder="shopify-section-sections--25210972849284__header"
+                value={controlSectionId}
+                label="Control Section ID"
                 disabled={isLocked || !editStructure}
                 onChange={(e) => {
-                  const value = Math.max(
-                    0,
-                    Math.min(100, Number(e.target.value)),
-                  );
-                  setVariantExperimentChance(value);
+                  const v = e.target.value;
+                  setControlSectionId(v);
                 }}
-                min={0}
-                max={100}
-                step={1}
-                suffix="%"
+                details="The control section ID that will be replaced by the variant for users who are in the experiment. Must be visible on production site"
               />
-            </s-stack>
+            )}
+            <s-text font-weight="heavy">
+              Control allocation: {controlAllocation}%. Control allocation is
+              calculated from the remaining percentage after all variants.
+            </s-text>
 
             <s-select
               label="Customer segment to test"
@@ -1353,17 +1381,17 @@ export default function EditExperiment() {
       >
         <s-button
           icon="minus"
-          accessibilityLabel="Remove item"
-          disabled={!variant || !editStructure || isLocked}
-          onClick={handleVariantUndo}
+          accessibilityLabel="Remove variant"
+          disabled={variants.length <= 1 || !editStructure || isLocked}
+          onClick={handleRemoveVariant}
         >
-          Remove Another Variant
+          Remove Variant
         </s-button>
         <s-button
           icon="plus"
-          accessibilityLabel="Add item"
-          disabled={variant || !editStructure || isLocked}
-          onClick={handleVariant}
+          accessibilityLabel="Add variant"
+          disabled={variants.length >= MAX_VARIANTS || !editStructure || isLocked}
+          onClick={handleAddVariant}
         >
           Add Another Variant
         </s-button>

--- a/app/routes/app.experiments.new.jsx
+++ b/app/routes/app.experiments.new.jsx
@@ -28,33 +28,44 @@ export const action = async ({ request }) => {
   const formData = await request.formData();
   const intent = formData.get("intent"); //for tutorialData
 
-  //tutorial db update 
-  if(intent === "tutorial_viewed")
-  {
+  //tutorial db update
+  if (intent === "tutorial_viewed") {
     try {
-        const { setCreateExpPage } = await import("../services/tutorialData.server");
-        await setCreateExpPage(1, true); //always sets the item in tutorialdata to true, selects 1st tuple
-        return {ok: true, action: "tutorial_viewed"}; 
-      } catch (error) {
-        console.error("Tutorial Error:", error);
-        return {ok: false, error: "Failed to update viewedListExperiment"}, { status: 500};
-      }
-  }
-  else
-  {
+      const { setCreateExpPage } = await import(
+        "../services/tutorialData.server"
+      );
+      await setCreateExpPage(1, true); //always sets the item in tutorialdata to true, selects 1st tuple
+      return { ok: true, action: "tutorial_viewed" };
+    } catch (error) {
+      console.error("Tutorial Error:", error);
+      return (
+        { ok: false, error: "Failed to update viewedListExperiment" },
+        { status: 500 }
+      );
+    }
+  } else {
     // Authenticate request
     const { session } = await authenticate.admin(request);
 
     // Get POST request form data & create experiment
     const name = (formData.get("name") || "").trim();
     const description = (formData.get("description") || "").trim();
-    const sectionId = (formData.get("sectionId") || "").trim();
     const controlSectionId = (formData.get("controlSectionId") || "").trim();
-    const variantSectionId = (formData.get("variantSectionId") || "").trim();
-    const variantEnabled = formData.get("variant") === "true";
     const goalValue = (formData.get("goal") || "").trim();
     const endCondition = (formData.get("endCondition") || "").trim();
-    const trafficSplitStr = (formData.get("trafficSplit") || "50").trim(); // Default to "0"
+
+    let variantInputs;
+    try {
+      variantInputs = JSON.parse(formData.get("variantsJSON") || "[]");
+    } catch {
+      variantInputs = [];
+    }
+    const sectionId = (variantInputs[0]?.sectionId || "").trim();
+    const totalTrafficPct = variantInputs.reduce(
+      (sum, v) => sum + (v.trafficAllocation || 0),
+      0,
+    );
+    const trafficSplitStr = String(totalTrafficPct);
     const probabilityToBeBestStr = (
       formData.get("probabilityToBeBest") || ""
     ).trim();
@@ -74,9 +85,12 @@ export const action = async ({ request }) => {
 
     if (!name) errors.name = "Name is required";
     if (!description) errors.description = "Description is required";
-    if (!sectionId) errors.sectionId = "Section Id is required";
-    if (variantEnabled && !variantSectionId)
-      errors.variantSectionId = "Variant Section Id is required"; //only validate if variant is true
+    variantInputs.forEach((v, i) => {
+      if (!(v.sectionId || "").trim()) {
+        errors[`variant_${i}_sectionId`] =
+          `Variant ${String.fromCharCode(65 + i)} Section ID is required`;
+      }
+    });
     if (!startDateStr && !startDateUTC)
       errors.startDate = "Start Date is required";
     if (endCondition === "stableSuccessProbability" && !probabilityToBeBestStr)
@@ -194,7 +208,9 @@ export const action = async ({ request }) => {
     });
 
     if (!goalRecord) {
-      return { errors: { goal: "Could not find matching goal in the database" } };
+      return {
+        errors: { goal: "Could not find matching goal in the database" },
+      };
     }
 
     // Convert form data strings to schema-ready types
@@ -213,33 +229,33 @@ export const action = async ({ request }) => {
     const duration = durationStr ? Number(durationStr) : null;
     const timeUnit = timeUnitValue || null;
 
-  // Assembles the final data object for Prisma
-  const experimentData = {
-    name: name,
-    description: description,
-    status: ExperimentStatus.draft,
-    trafficSplit: trafficSplit,
-    endCondition: endCondition,
-    startDate: startDate,
-    endDate: endDate,
-    sectionId: sectionId,
-    controlSectionId: controlSectionId,
-    project: {
-      // Connect to the parent project
-      connect: {
-        id: projectId,
-      },
-    },
-    experimentGoals: {
-      // Create the related goal
-      create: [
-        {
-          goalId: goalId,
-          goalRole: "primary",
+    // Assembles the final data object for Prisma
+    const experimentData = {
+      name: name,
+      description: description,
+      status: ExperimentStatus.draft,
+      trafficSplit: trafficSplit,
+      endCondition: endCondition,
+      startDate: startDate,
+      endDate: endDate,
+      sectionId: sectionId,
+      controlSectionId: controlSectionId,
+      project: {
+        // Connect to the parent project
+        connect: {
+          id: projectId,
         },
-      ],
-    },
-  };
+      },
+      experimentGoals: {
+        // Create the related goal
+        create: [
+          {
+            goalId: goalId,
+            goalRole: "primary",
+          },
+        ],
+      },
+    };
 
     if (isStableSuccessProbability) {
       Object.assign(experimentData, {
@@ -249,19 +265,20 @@ export const action = async ({ request }) => {
       });
     }
 
-  const { createExperiment } = await import("../services/experiment.server");
-  const experiment = await createExperiment(experimentData, {
-    variantEnabled,
-    controlSectionId,
-    primaryVariantSectionId: sectionId,
-    secondaryVariantSectionId: variantSectionId,
-  });
+    const treatmentVariants = variantInputs.map((v) => ({
+      sectionId: (v.sectionId || "").trim(),
+      trafficAllocation: (v.trafficAllocation || 0) / 100.0,
+    }));
+
+    const { createExperiment } = await import("../services/experiment.server");
+    const experiment = await createExperiment(experimentData, {
+      controlSectionId,
+      variants: treatmentVariants,
+    });
 
     return redirect(`/app/experiments/${experiment.id}`);
-    }
-  }; //end async action
-
-  
+  }
+}; //end async action
 
 //pull the default goal stored in database, completedCheckout if empty
 export const loader = async ({ request }) => {
@@ -271,50 +288,47 @@ export const loader = async ({ request }) => {
     select: { defaultGoal: true },
   });
 
-    //looks up tutorial data
-  const { getTutorialData } = await import ("../services/tutorialData.server");
+  //looks up tutorial data
+  const { getTutorialData } = await import("../services/tutorialData.server");
   const tutorialInfo = await getTutorialData();
 
-  return { defaultGoal: project?.defaultGoal ?? "completedCheckout",
-           tutorialData: tutorialInfo
-   };
+  return {
+    defaultGoal: project?.defaultGoal ?? "completedCheckout",
+    tutorialData: tutorialInfo,
+  };
 };
 
 //--------------------------- client side ----------------------------------------
 
-
 export default function CreateExperiment() {
   //fetcher stores the data in the fields into a form that can be retrieved
   const fetcher = useFetcher();
-  const { defaultGoal, tutorialData} = useLoaderData();
+  const { defaultGoal, tutorialData } = useLoaderData();
   const tutorialFetcher = useFetcher();
   const modalRef = useRef(null);
 
-
- 
   const [tutorialDismissed, setTutorialDismissed] = useState(false); //this page needs to track tutorial display locally and on db
   //state variables (special variables that remember across re-renders (e.g. user input, counters))
   const [name, setName] = useState("");
   const [nameError, setNameError] = useState(null);
   const [description, setDescription] = useState("");
   const [emptyDescriptionError, setDescriptionError] = useState(null);
-  const [sectionId, setSectionId] = useState("");
+  const MAX_VARIANTS = 4;
+  const VARIANT_LABELS = ["A", "B", "C", "D"];
+
+  const [variants, setVariants] = useState([
+    { sectionId: "", trafficAllocation: 50 },
+  ]);
+  const [variantSectionErrors, setVariantSectionErrors] = useState([null]);
   const [addControlSection, setAddControlSection] = useState(false);
   const [controlSectionId, setControlSectionId] = useState("");
-  const [emptySectionIdError, setSectionIdError] = useState(null);
-  const [emptySectionIdVariantError, setSectionIdVariantError] = useState(null);
   const [emptyStartDateError, setEmptyStartDateError] = useState(null);
   const [emptyEndDateError, setEmptyEndDateError] = useState(null);
   const [endDate, setEndDate] = useState("");
   const [endDateError, setEndDateError] = useState("");
-  const [experimentChance, setExperimentChance] = useState(50);
   const [endCondition, setEndCondition] = useState("manual");
   const [goalSelected, setGoalSelected] = useState(defaultGoal);
   const [customerSegment, setCustomerSegment] = useState("allSegments");
-  const [variant, setVariant] = useState(false);
-  const [variantDisplay, setVariantDisplay] = useState("none");
-  const [variantSectionId, setVariantSectionId] = useState("");
-  const [variantExperimentChance, setVariantExperimentChance] = useState(50);
   const [startDate, setStartDate] = useState("");
   const [startDateError, setStartDateError] = useState("");
   const [startTime, setStartTime] = useState("");
@@ -322,14 +336,18 @@ export default function CreateExperiment() {
   const [startTimeError, setStartTimeError] = useState("");
   const [endTimeError, setEndTimeError] = useState("");
 
-   //tutorial display conditional 
-  useEffect(() =>
-  {
-    if (!tutorialDismissed && (tutorialData.createExperiment == false) && modalRef.current && typeof modalRef.current.showOverlay === 'function') {
+  //tutorial display conditional
+  useEffect(() => {
+    if (
+      !tutorialDismissed &&
+      tutorialData.createExperiment == false &&
+      modalRef.current &&
+      typeof modalRef.current.showOverlay === "function"
+    ) {
       modalRef.current.showOverlay();
     }
   }, [tutorialData]);
-    
+
   useEffect(() => {
     // keep all date/time errors in sync whenever any date/time value changes
     const errors = validateAllDateTimes(startDate, startTime, endDate, endTime);
@@ -343,7 +361,6 @@ export default function CreateExperiment() {
       setEndTimeError(errors.endTimeError);
 
     //checks for tutorial data
-
   }, [startDate, startTime, endDate, endTime, endCondition]);
 
   // clear end fields / errors when user switches end condition away from "endDate"
@@ -367,16 +384,17 @@ export default function CreateExperiment() {
 
   const errors = fetcher.data?.errors || {}; // looks for error data, if empty instantiate errors as empty object
 
-  //Check if there were any errors on the form
+  const controlAllocation = Math.max(
+    0,
+    100 - variants.reduce((sum, v) => sum + v.trafficAllocation, 0),
+  );
+
   const hasClientErrors =
     !!nameError ||
     !!errors.name ||
     !!emptyDescriptionError ||
     !!errors.description ||
-    !!emptySectionIdError ||
-    !!errors.sectionId ||
-    (variant && !!emptySectionIdVariantError) ||
-    (variant && !!errors.variantSectionId) ||
+    variantSectionErrors.some((e) => !!e) ||
     !!probabilityToBeBestError ||
     !!errors.probabilityToBeBest ||
     !!durationError ||
@@ -407,18 +425,15 @@ export default function CreateExperiment() {
     const experimentData = {
       name: name,
       description: description,
-      sectionId: sectionId,
       controlSectionId: controlSectionId,
-      variantSectionId: variantSectionId,
-      variant: String(variant),
-      goal: goalSelected, // holds the "view-page" value
-      endCondition: endCondition, // holds "Manual", "End Data"
-      startDateUTC: startDateUTC, // The date string from s-date-field
-      endDateUTC: endDateUTC, // The date string from s-date-field
-      endDate: endDate, // The date string from s-date-field
-      trafficSplit: experimentChance, // 0-100 value
-      probabilityToBeBest: probabilityToBeBest, //holds validated value 51-100
-      duration: duration, //length of time for experiment run
+      variantsJSON: JSON.stringify(variants),
+      goal: goalSelected,
+      endCondition: endCondition,
+      startDateUTC: startDateUTC,
+      endDateUTC: endDateUTC,
+      endDate: endDate,
+      probabilityToBeBest: probabilityToBeBest,
+      duration: duration,
       timeUnit: timeUnit,
     };
 
@@ -446,20 +461,20 @@ export default function CreateExperiment() {
     }
   };
 
-  const handleSectionIdBlur = () => {
-    if (!sectionId.trim()) {
-      setSectionIdError("Section ID is a required field");
-    } else {
-      setSectionIdError(null); //clears error once user fixes
-    }
+  const updateVariant = (index, field, value) => {
+    setVariants((prev) =>
+      prev.map((v, i) => (i === index ? { ...v, [field]: value } : v)),
+    );
   };
 
-  const handleSectionIdVariantBlur = () => {
-    if (variant && !variantSectionId.trim()) {
-      setSectionIdVariantError("Section ID is a required field");
-    } else {
-      setSectionIdVariantError(null); //clears error once user fixes
-    }
+  const handleVariantSectionIdBlur = (index) => {
+    setVariantSectionErrors((prev) => {
+      const next = [...prev];
+      next[index] = !variants[index].sectionId.trim()
+        ? "Section ID is a required field"
+        : null;
+      return next;
+    });
   };
 
   const handleStartDateBlur = () => {
@@ -647,28 +662,34 @@ export default function CreateExperiment() {
     setEndTimeError(errors.endTimeError);
   };
 
-  const handleVariant = () => {
-    setVariant(true);
-    setVariantDisplay("auto");
-    setVariantExperimentChance(50);
+  const handleAddVariant = () => {
+    if (variants.length >= MAX_VARIANTS) return;
+    const newCount = variants.length + 1;
+    const evenSplit = Math.floor(100 / (newCount + 1));
+    setVariants((prev) => [
+      ...prev.map((v) => ({ ...v, trafficAllocation: evenSplit })),
+      { sectionId: "", trafficAllocation: evenSplit },
+    ]);
+    setVariantSectionErrors((prev) => [...prev, null]);
   };
 
-  const handleVariantUndo = () => {
-    setVariant(false);
-    setVariantDisplay("none");
-    setVariantSectionId("");
-    setVariantExperimentChance();
+  const handleRemoveVariant = () => {
+    if (variants.length <= 1) return;
+    const newCount = variants.length - 1;
+    const evenSplit = Math.floor(100 / (newCount + 1));
+    setVariants((prev) =>
+      prev.slice(0, -1).map((v) => ({ ...v, trafficAllocation: evenSplit })),
+    );
+    setVariantSectionErrors((prev) => prev.slice(0, -1));
   };
 
   const handleDiscard = () => {
     setName("");
     setDescription("");
-    setSectionId("");
-    setVariant(false);
-    setVariantDisplay("none");
-    setVariantSectionId("");
-    setExperimentChance(50);
-    setVariantExperimentChance(50);
+    setVariants([{ sectionId: "", trafficAllocation: 50 }]);
+    setVariantSectionErrors([null]);
+    setAddControlSection(false);
+    setControlSectionId("");
     setGoalSelected(defaultGoal);
     setCustomerSegment("allSegments");
     setEndCondition("manual");
@@ -682,8 +703,6 @@ export default function CreateExperiment() {
 
     setNameError(null);
     setDescriptionError(null);
-    setSectionIdError(null);
-    setSectionIdVariantError(null);
     setEmptyStartDateError(null);
     setEmptyEndDateError(null);
     setStartDateError("");
@@ -695,7 +714,6 @@ export default function CreateExperiment() {
     setTimeUnitError("");
   };
 
-  
   const descriptionError = errors.description;
 
   // map internal values to a label + icon
@@ -712,16 +730,6 @@ export default function CreateExperiment() {
     mobileVisitors: "Mobile Visitors",
   };
 
-  const variationMap = {
-    false: "Single Variation",
-    true: "Multiple Variations",
-  };
-
-  const variantMap = {
-    false: "none",
-    true: "auto",
-  };
-
   // derive current badge info and icon from selected goal
   const { label, icon } = goalMap[goalSelected] ?? {
     label: "—",
@@ -733,33 +741,33 @@ export default function CreateExperiment() {
     <s-page heading="Create Experiment" variant="headingLg">
       {/*modal popup for tutorial */}
       <s-modal
-            id="tutorial-modal-create-exp"
-            ref={modalRef}
-            heading="Quick tour"
-            padding="base"
-            size="base"
+        id="tutorial-modal-create-exp"
+        ref={modalRef}
+        heading="Quick tour"
+        padding="base"
+        size="base"
+      >
+        <s-stack gap="base">
+          <s-paragraph>Here is some tutorial information.</s-paragraph>
+
+          <s-button
+            variant="primary"
+            inLineSize="fill"
+            commandFor="tutorial-modal-create-exp"
+            command="--hide"
+            onClick={() => {
+              setTutorialDismissed(true);
+              tutorialFetcher.submit(
+                { intent: "tutorial_viewed" },
+                { method: "post" },
+              );
+            }}
           >
-          <s-stack gap="base">
-            <s-paragraph>
-              Here is some tutorial information.
-            </s-paragraph>
-          
-              <s-button
-              variant="primary"
-              inLineSize = "fill"
-              commandFor="tutorial-modal-create-exp"
-              command="--hide"
-              onClick = {() => {
-                setTutorialDismissed(true)
-                tutorialFetcher.submit(
-                  { intent: "tutorial_viewed"},
-                  {method: "post"}
-                )
-              }}
-              > Understood. Do not show this again.
-              </s-button>
-          </s-stack>
-        </s-modal>
+            {" "}
+            Understood. Do not show this again.
+          </s-button>
+        </s-stack>
+      </s-modal>
       <s-button
         slot="primary-action"
         variant="primary"
@@ -794,32 +802,32 @@ export default function CreateExperiment() {
         <s-section heading={name ? name : "no experiment name set"}>
           <s-stack gap="small">
             <s-badge icon={icon}>{label}</s-badge>
-            <s-badge
-              tone={sectionId ? "" : "warning"}
-              icon={sectionId ? "code" : "alert-circle"}
-            >
-              {sectionId || "Section not selected"}
-            </s-badge>
-            <s-stack display={variantDisplay}>
+            {variants.map((v, i) => (
               <s-badge
-                tone={variantSectionId ? "" : "warning"}
-                icon={variantSectionId ? "code" : "alert-circle"}
+                key={i}
+                tone={v.sectionId ? "" : "warning"}
+                icon={v.sectionId ? "code" : "alert-circle"}
               >
-                {variantSectionId || "Section not selected"}
+                Variant {VARIANT_LABELS[i]}:{" "}
+                {v.sectionId || "Section not selected"}
               </s-badge>
-            </s-stack>
+            ))}
 
             <s-text font-weight="heavy">Experiment Details</s-text>
 
-            {/* DYNAMIC BULLET LIST */}
             <s-text>• {customerSegments}</s-text>
-            <s-text>• {variationMap[variant] || "—"}</s-text>
-            <s-text>• {experimentChance}% Chance to show Variant 1</s-text>
-            <s-stack display={variantDisplay}>
-              <s-text>
-                • {variantExperimentChance}% Chance to show Variant 2
+            <s-text>
+              •{" "}
+              {variants.length === 1
+                ? "Single Variation"
+                : `${variants.length} Variations`}
+            </s-text>
+            {variants.map((v, i) => (
+              <s-text key={i}>
+                • {v.trafficAllocation}% Variant {VARIANT_LABELS[i]}
               </s-text>
-            </s-stack>
+            ))}
+            <s-text>• {controlAllocation}% Control</s-text>
             <s-text>
               • Active from{" "}
               {startDate
@@ -927,54 +935,88 @@ export default function CreateExperiment() {
       <s-section heading="Experiment Details">
         <s-form>
           <s-stack direction="block" gap="base" paddingBlock="base">
-            <s-stack direction="block" gap="small">
-              <s-stack display={variantDisplay}>
-                <s-heading>Variant 1</s-heading>
-              </s-stack>
-              {/*Custom Label Row (SectionID + help link)*/}
-              <s-link href="#" target="_blank">
-                How do I find my section?
-              </s-link>
-              <s-text-field
-                placeholder="shopify-section-sections--25210977943842__header"
-                value={sectionId}
-                label="Section ID to be tested"
-                required
-                onFocus={() => {
-                  setSectionIdError(null);
-                  if (fetcher.data?.errors?.sectionId) {
-                    //clear server-side errors by resetting fetcher data
-                    fetcher.data = {
-                      ...fetcher.data,
-                      errors: { ...fetcher.data.errors, sectionId: undefined },
-                    };
+            {variants.map((variant, i) => (
+              <s-stack
+                key={i}
+                direction="block"
+                gap="small"
+                paddingBlock={i > 0 ? "base" : undefined}
+              >
+                <s-heading>Variant {VARIANT_LABELS[i]}</s-heading>
+                <s-link href="#" target="_blank">
+                  How do I find my section?
+                </s-link>
+                <s-text-field
+                  placeholder="shopify-section-sections--25210977943842__header"
+                  value={variant.sectionId}
+                  label="Section ID to be tested"
+                  required
+                  onFocus={() => {
+                    setVariantSectionErrors((prev) => {
+                      const next = [...prev];
+                      next[i] = null;
+                      return next;
+                    });
+                    if (fetcher.data?.errors?.[`variant_${i}_sectionId`]) {
+                      fetcher.data = {
+                        ...fetcher.data,
+                        errors: {
+                          ...fetcher.data.errors,
+                          [`variant_${i}_sectionId`]: undefined,
+                        },
+                      };
+                    }
+                  }}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    updateVariant(i, "sectionId", val);
+                    if (variantSectionErrors[i] && val.trim()) {
+                      setVariantSectionErrors((prev) => {
+                        const next = [...prev];
+                        next[i] = null;
+                        return next;
+                      });
+                    }
+                  }}
+                  onBlur={() => handleVariantSectionIdBlur(i)}
+                  error={
+                    variantSectionErrors[i] || errors[`variant_${i}_sectionId`]
                   }
-                }}
-                onChange={(e) => {
-                  const v = e.target.value;
-                  setSectionId(v);
-                  if (emptySectionIdError && v.trim()) setSectionIdError(null);
-                }}
-                onBlur={handleSectionIdBlur}
-                error={errors.sectionId || emptySectionIdError}
-                details="The associated Shopify section ID to be tested. Must be visible on production site"
-              />
-            </s-stack>
+                  details="The associated Shopify section ID to be tested. Must be visible on production site"
+                />
+                <s-number-field
+                  label={`Traffic allocation for Variant ${VARIANT_LABELS[i]}`}
+                  value={variant.trafficAllocation}
+                  inputMode="numeric"
+                  onChange={(e) => {
+                    const othersTotal = variants.reduce(
+                      (sum, v, idx) => (idx !== i ? sum + v.trafficAllocation : sum),
+                      0,
+                    );
+                    const maxAllowed = 100 - othersTotal;
+                    const value = Math.max(0, Math.min(maxAllowed, Number(e.target.value)));
+                    updateVariant(i, "trafficAllocation", value);
+                  }}
+                  min={0}
+                  max={100 - variants.reduce((sum, v, idx) => (idx !== i ? sum + v.trafficAllocation : sum), 0)}
+                  step={1}
+                  suffix="%"
+                />
+              </s-stack>
+            ))}
+
             <s-checkbox
               label="Add a control section ID"
               details="If you want the variant section to replace the control section, add a control section ID"
-              onChange={(e) => {
+              onChange={() => {
                 setAddControlSection(!addControlSection);
               }}
             />
-            {/* There is no error checking for this section intentionally. If a user supplies a control ID, that's great */}
-            {/* But, you don't need it and may not want it, so it can be blank. */}
             {addControlSection && (
               <s-text-field
                 placeholder="shopify-section-sections--25210972849284__header"
                 value={controlSectionId}
                 label="Control Section ID"
-                required
                 onChange={(e) => {
                   const v = e.target.value;
                   setControlSectionId(v);
@@ -982,78 +1024,11 @@ export default function CreateExperiment() {
                 details="The control section ID that will be replaced by the variant for users who are in the experiment. Must be visible on production site"
               />
             )}
-            <s-number-field
-              label="Chance to show experiment"
-              value={experimentChance}
-              inputMode="numeric"
-              onChange={(e) => {
-                const value = Math.max(
-                  0,
-                  Math.min(100, Number(e.target.value)),
-                );
-                setExperimentChance(value);
-              }}
-              min={0}
-              max={100}
-              step={1}
-              suffix="%"
-            />
-            {/* Variant 2 fields */}
-            <s-stack display={variantDisplay} paddingBlock="base">
-              <s-heading>Variant 2</s-heading>
+            <s-text font-weight="heavy">
+              Control allocation: {controlAllocation}%. Control allocation is
+              calculated from the remaining percentage after all variants.
+            </s-text>
 
-              <s-stack direction="block" gap="small" paddingBlock="base">
-                {/*Custom Label Row (SectionID + help link)*/}
-                <s-link href="#" target="_blank">
-                  How do I find my section?
-                </s-link>
-                <s-text-field
-                  placeholder="shopify-section-sections--25210977943842__header"
-                  value={variantSectionId}
-                  label="Section ID to be tested"
-                  required
-                  onFocus={() => {
-                    setSectionIdVariantError(null);
-                    if (fetcher.data?.errors?.variantSectionId) {
-                      //clear server-side errors by resetting fetcher data
-                      fetcher.data = {
-                        ...fetcher.data,
-                        errors: {
-                          ...fetcher.data.errors,
-                          variantSectionId: undefined,
-                        },
-                      };
-                    }
-                  }}
-                  onChange={(e) => {
-                    const v = e.target.value;
-                    setVariantSectionId(v);
-                    if (emptySectionIdVariantError && v.trim())
-                      setSectionIdVariantError(null);
-                  }}
-                  onBlur={handleSectionIdVariantBlur}
-                  error={errors.variantSectionId || emptySectionIdVariantError}
-                  details="The associated Shopify section ID to be tested. Must be visible on production site"
-                />
-              </s-stack>
-
-              <s-number-field
-                label="Chance to show experiment"
-                value={variantExperimentChance}
-                inputMode="numeric"
-                onChange={(e) => {
-                  const value = Math.max(
-                    0,
-                    Math.min(100, Number(e.target.value)),
-                  );
-                  setExperimentChance(value);
-                }}
-                min={0}
-                max={100}
-                step={1}
-                suffix="%"
-              />
-            </s-stack>
             <s-select
               label="Customer segment to test"
               value={customerSegment}
@@ -1078,17 +1053,17 @@ export default function CreateExperiment() {
       >
         <s-button
           icon="minus"
-          accessibilityLabel="Remove item"
-          disabled={!variant}
-          onClick={handleVariantUndo}
+          accessibilityLabel="Remove variant"
+          disabled={variants.length <= 1}
+          onClick={handleRemoveVariant}
         >
-          Remove Another Variant
+          Remove Variant
         </s-button>
         <s-button
           icon="plus"
-          accessibilityLabel="Add item"
-          disabled={variant}
-          onClick={handleVariant}
+          accessibilityLabel="Add variant"
+          disabled={variants.length >= MAX_VARIANTS}
+          onClick={handleAddVariant}
         >
           Add Another Variant
         </s-button>
@@ -1330,15 +1305,14 @@ export default function CreateExperiment() {
       </s-section>
       <div style={{ marginBottom: "250px" }}>
         <s-stack direction="inline" gap="small" justifyContent="end">
-          <s-button 
-            onClick={handleDiscard}
-            variant="secondary">
+          <s-button onClick={handleDiscard} variant="secondary">
             Discard
           </s-button>
-          <s-button 
-            variant="primary" 
-            disabled={hasClientErrors || isSubmitting} 
-            onClick={handleExperimentCreate}>
+          <s-button
+            variant="primary"
+            disabled={hasClientErrors || isSubmitting}
+            onClick={handleExperimentCreate}
+          >
             Save Draft
           </s-button>
         </s-stack>

--- a/app/routes/app.reports.$id.jsx
+++ b/app/routes/app.reports.$id.jsx
@@ -196,9 +196,8 @@ export default function Report() {
   
   const PROB_THRESHOLD = 0.8;
   const DELTA_THRESHOLD = 0.01;
-  const control = analysis[0]; // baseline
+  const control = analysis.find(a => a.variantName === "Control");
 
-  // if no analysis exists yet
   if (!control){
     return {
       status: 'default',
@@ -209,7 +208,8 @@ export default function Report() {
   
   /* Searches for variants in the experiment which 
   *  currently have a PoB >= 80% */ 
-  const currentWinners = analysis.slice(1).filter(variant => {
+  const currentWinners = analysis.filter(variant => {
+    if (variant.variantName === "Control") return false;
     const delta = variant.conversionRate - control.conversionRate;
     return variant.probabilityOfBeingBest >= PROB_THRESHOLD && delta > DELTA_THRESHOLD;
   });
@@ -270,15 +270,16 @@ export default function Report() {
 
   // Table code
   function renderTableData() {
-    if (analysis.length === 0 ) return []; // simple exit if the array is empty
+    if (safeAnalysis.length === 0) return [];
     const rows = [];
-    const control = safeAnalysis[0]; // Reference the baseline for delta calculations
+    const control = safeAnalysis.find(a => a.variantName === "Control");
 
     for (let i = 0; i < safeAnalysis.length; i++) {
       const cur = safeAnalysis[i];
+      const isControl = cur.variantName === "Control";
       
       // Probability to be Best: 80% Win / 20% Loss rule
-      let probColor = "inherit"; // inherit ensures the default font color is used if no winner/loser
+      let probColor = "inherit";
       if (cur.probabilityOfBeingBest > 0.8) probColor = "#2e7d32"; 
       else if (cur.probabilityOfBeingBest < 0.2) probColor = "#d32f2f";
 
@@ -288,7 +289,7 @@ export default function Report() {
 
       // Goal Completion Rate: Delta > 1% rule
       let rateColor = "inherit";
-      if (i > 0 && control) {
+      if (!isControl && control) {
         const delta = (cur.conversionRate - control.conversionRate) * 100;
         if (delta > 1) rateColor = "#2e7d32";
         else if (delta < -1) rateColor = "#d32f2f";
@@ -296,7 +297,7 @@ export default function Report() {
 
       // Improvement rule (> 50% Win, < 0% Loss)
       let impColor = "inherit";
-      if (i>0){ // skips Control since it's BaseLine
+      if (!isControl) {
         if (cur.improvement > 50){
           impColor = "#2e7d32";
         } else if (cur.improvement < 0){
@@ -316,7 +317,7 @@ export default function Report() {
           </s-table-cell>
           <s-table-cell>
             <span style = {{color: impColor}}> 
-              {i === 0 ? 'Baseline' : formatPercent(cur.improvement / 100)}
+              {isControl ? 'Baseline' : formatPercent(cur.improvement / 100)}
             </span>
           </s-table-cell>
           {/* Probability to be Best: 80/20 significance rule */}

--- a/app/services/experiment.server.js
+++ b/app/services/experiment.server.js
@@ -5,44 +5,54 @@ import { Prisma } from "@prisma/client";
 import { ExperimentStatus } from "@prisma/client";
 
 // Function to create an experiment. Returns the created experiment object.
+// Accepts an array of treatment variant objects, each with { sectionId, trafficAllocation }.
+// A Control variant is always created automatically with the remaining traffic.
+// Variant names are auto-generated: "Control", "Variant A", "Variant B", "Variant C", ...
 export async function createExperiment(
   experimentData,
-  {
-    variantEnabled = false,
-    controlSectionId = "",
-    primaryVariantSectionId = "",
-    secondaryVariantSectionId = "",
-  } = {},
+  { controlSectionId = "", variants = [] } = {},
 ) {
   console.log("Creating experiment with data:", experimentData);
+
+  const VARIANT_LABELS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+  const treatmentAllocation = variants.reduce(
+    (sum, v) => sum + (v.trafficAllocation || 0),
+    0,
+  );
+  const controlAllocation = 1.0 - treatmentAllocation;
+
+  if (controlAllocation < -0.01) {
+    throw new Error(
+      `Treatment traffic allocations exceed 1.0 (sum: ${treatmentAllocation.toFixed(4)})`,
+    );
+  }
+
+  if (Math.abs(treatmentAllocation + Math.max(0, controlAllocation) - 1.0) > 0.01) {
+    throw new Error(
+      `Traffic allocations must sum to ~1.0 (got ${(treatmentAllocation + controlAllocation).toFixed(4)})`,
+    );
+  }
 
   const variantCreates = [];
 
   variantCreates.push({
     name: "Control",
-    configData: controlSectionId
-      ? { sectionId: controlSectionId }
-      : null,
+    configData: controlSectionId ? { sectionId: controlSectionId } : null,
+    trafficAllocation: Math.max(0, controlAllocation),
   });
 
-  if (primaryVariantSectionId) {
+  variants.forEach((v, i) => {
     variantCreates.push({
-      name: "Variant A",
-      configData: { sectionId: primaryVariantSectionId },
+      name: `Variant ${VARIANT_LABELS[i]}`,
+      configData: v.sectionId ? { sectionId: v.sectionId } : null,
+      trafficAllocation: v.trafficAllocation,
     });
-  }
+  });
 
-  if (variantEnabled && secondaryVariantSectionId) {
-    variantCreates.push({
-      name: "Variant B",
-      configData: { sectionId: secondaryVariantSectionId },
-    });
-  }
-
-  // Update Prisma database using npx prisma
   const result = await db.experiment.create({
     data: {
-      ...experimentData, // Will include all DB fields of a new experiment
+      ...experimentData,
       variants: {
         create: variantCreates,
       },

--- a/app/services/experiment.server.js
+++ b/app/services/experiment.server.js
@@ -66,7 +66,7 @@ export async function createExperiment(
    Experiment Queries
    ==================================================================================================== */
 
-// Get active experiment ID, Section ID and Probability - used on frontend for showing.
+// Returns active experiments with variant-level data for the storefront embed script.
 export async function GetFrontendExperimentsData() {
   const experiments = await db.experiment.findMany({
     where: {
@@ -74,13 +74,27 @@ export async function GetFrontendExperimentsData() {
     },
     select: {
       id: true,
-      sectionId: true,
-      controlSectionId: true,
-      trafficSplit: true,
+      variants: {
+        select: {
+          id: true,
+          name: true,
+          configData: true,
+          trafficAllocation: true,
+        },
+      },
     },
   });
 
-  return experiments;
+  return experiments.map((exp) => ({
+    id: exp.id,
+    variants: exp.variants.map((v) => ({
+      id: v.id,
+      name: v.name,
+      sectionId: v.configData?.sectionId ?? null,
+      trafficAllocation: Number(v.trafficAllocation),
+      isControl: v.name === "Control",
+    })),
+  }));
 }
 
 // Function to get experiments list.

--- a/extensions/ab-insightful-embed/assets/ab-insightful-embed.js
+++ b/extensions/ab-insightful-embed/assets/ab-insightful-embed.js
@@ -11,113 +11,133 @@ if (appConfigBlock) {
 }
 
 function initializeApp(appUrl) {
-  const experimentsAPIUrl = `${appUrl}/api/experiments`;
-  let experiment_ids = {};
-  fetch(experimentsAPIUrl, {
-    method: "GET",
-  })
-    .then((res) => {
-      return res.json();
-    })
-    .then((data) => {
-      data.forEach((experiment) => {
-        const variantMatch = document.getElementById(experiment.sectionId);
-        if (variantMatch) {
-          console.log(
-            `[ab-insightful-embed] Match! ID: ${experiment.sectionId} Element: ${variantMatch}`,
-          );
-          if (experiment.controlSectionId) {
-            const controlMatch = document.getElementById(
-              experiment.controlSectionId,
-            );
-            // Variant has a control element that needs to be hidden if the user is in variant group
-            if (controlMatch) {
-              invokeExperiment(
-                experiment.id,
-                experiment.trafficSplit,
-                variantMatch,
-                appUrl,
-                controlMatch,
-              );
-            }
-          } else {
-            invokeExperiment(
-              experiment.id,
-              experiment.trafficSplit,
-              variantMatch,
-              appUrl,
-            );
-          }
-        }
+  fetch(`${appUrl}/api/experiments`, { method: "GET" })
+    .then((res) => res.json())
+    .then((experiments) => {
+      const assignments = migrateOldCookies(getAssignments(), experiments);
+
+      experiments.forEach((experiment) => {
+        processExperiment(experiment, assignments, appUrl);
       });
+
+      saveAssignments(assignments);
     })
-    .catch((error) => {
-      console.log(error);
+    .catch((err) => {
+      console.error("[ab-insightful] Failed to fetch experiments:", err);
     });
 }
 
-// Function to decide whether to activate an experiment for the current client given an active experiment
-function invokeExperiment(
-  id,
-  chanceToShow,
-  element,
-  appUrl,
-  controlElement = null,
-) {
-  // Two cookies - one for experiments involved in control, one for involved in variants
-  // Both are comma separated lists of id's
-  const involvedControlExperiments = getCookie("ab-control-ids");
-  const involvedVariantExperiments = getCookie("ab-variant-ids");
-  // Check if this user is already in the experiment as a control
-  if (involvedControlExperiments) {
-    const expids = involvedControlExperiments.split(",");
-    if (expids.includes(String(id))) {
-      element.style.display = "none";
-      return;
+function processExperiment(experiment, assignments, appUrl) {
+  // Only relevant if at least one variant section exists on this page
+  const variantsOnPage = experiment.variants.filter(
+    (v) => v.sectionId && document.getElementById(v.sectionId),
+  );
+  if (variantsOnPage.length === 0) return;
+
+  const expKey = String(experiment.id);
+  let assignedVariant = null;
+  let isNew = false;
+
+  // Check for an existing assignment
+  if (assignments[expKey] != null) {
+    assignedVariant = experiment.variants.find(
+      (v) => v.id === assignments[expKey],
+    );
+    // If the stored variant no longer exists in the experiment, reassign
+    if (!assignedVariant) {
+      delete assignments[expKey];
     }
   }
 
-  // Check if this user is already in the experiment as a variant
-  if (involvedVariantExperiments) {
-    const expids = involvedVariantExperiments.split(",");
-    if (expids.includes(String(id))) {
-      if (controlElement) {
-        controlElement.style.display = "none";
-      }
-      return;
-    }
+  // New assignment via weighted random selection
+  if (!assignedVariant) {
+    assignedVariant = weightedRandomSelect(experiment.variants);
+    isNew = true;
   }
 
-  // Base case: not in control or variant list - add to experiment
-  const chance = Number(chanceToShow);
-  if (Math.random() <= chance) {
-    // You are part of experiment - hide control
-    if (controlElement) {
-        controlElement.style.display = "none";
-      }
-    // Add to variant experiment
-    document.cookie =
-      "ab-variant-ids=" +
-      (involvedVariantExperiments ? involvedVariantExperiments + "," : "") +
-      id +
-      "; path=/";
+  assignments[expKey] = assignedVariant.id;
 
-    // Setup data to send to server to notify of new experiment user
-    const user_id = getCookie("_shopify_y");
-    submitExperimentUser(user_id, id, "Variant A", appUrl);
-  } else {
-    // You are part of control group - hide experiment
-    element.style.display = "none";
-    // Add to control group
-    document.cookie =
-      "ab-control-ids=" +
-      (involvedControlExperiments ? involvedControlExperiments + "," : "") +
-      id +
-      "; path=/";
-    // Include user in Control on server
-    const user_id = getCookie("_shopify_y");
-    submitExperimentUser(user_id, id, "Control", appUrl);
+  // Show assigned variant section, hide every other variant section
+  experiment.variants.forEach((v) => {
+    if (!v.sectionId) return;
+    const el = document.getElementById(v.sectionId);
+    if (!el) return;
+    el.style.display = v.id === assignedVariant.id ? "" : "none";
+  });
+
+  if (isNew) {
+    const userId = getCookie("_shopify_y");
+    submitExperimentUser(userId, experiment.id, assignedVariant.name, appUrl);
   }
+}
+
+// Pick one variant using cumulative traffic allocation weights.
+function weightedRandomSelect(variants) {
+  const rand = Math.random();
+  let cumulative = 0;
+  for (const v of variants) {
+    cumulative += v.trafficAllocation;
+    if (rand < cumulative) return v;
+  }
+  return variants[variants.length - 1];
+}
+
+// --- Cookie helpers ---
+
+function getAssignments() {
+  const raw = getCookie("ab-assignments");
+  if (!raw) return {};
+  try {
+    return JSON.parse(decodeURIComponent(raw));
+  } catch {
+    return {};
+  }
+}
+
+function saveAssignments(assignments) {
+  const encoded = encodeURIComponent(JSON.stringify(assignments));
+  document.cookie = "ab-assignments=" + encoded + "; path=/; max-age=31536000";
+}
+
+// Migrate legacy ab-control-ids / ab-variant-ids cookies into the new format
+// so returning visitors keep their original assignment.
+function migrateOldCookies(assignments, experiments) {
+  const oldControl = getCookie("ab-control-ids");
+  const oldVariant = getCookie("ab-variant-ids");
+  if (!oldControl && !oldVariant) return assignments;
+
+  const expMap = {};
+  experiments.forEach((exp) => {
+    expMap[String(exp.id)] = exp.variants;
+  });
+
+  if (oldControl) {
+    oldControl.split(",").forEach((raw) => {
+      const id = raw.trim();
+      if (!id || assignments[id] != null) return;
+      const variants = expMap[id];
+      if (!variants) return;
+      const control = variants.find((v) => v.isControl);
+      if (control) assignments[id] = control.id;
+    });
+  }
+
+  if (oldVariant) {
+    oldVariant.split(",").forEach((raw) => {
+      const id = raw.trim();
+      if (!id || assignments[id] != null) return;
+      const variants = expMap[id];
+      if (!variants) return;
+      const treatment = variants.find((v) => !v.isControl);
+      if (treatment) assignments[id] = treatment.id;
+    });
+  }
+
+  // Clear legacy cookies
+  document.cookie = "ab-control-ids=; path=/; max-age=0";
+  document.cookie = "ab-variant-ids=; path=/; max-age=0";
+
+  return assignments;
 }
 
 function getCookie(name) {
@@ -125,38 +145,32 @@ function getCookie(name) {
   const ca = document.cookie.split(";");
   for (let i = 0; i < ca.length; i++) {
     let c = ca[i];
-    while (c.charAt(0) === " ") {
-      c = c.substring(1, c.length);
-    }
-    if (c.indexOf(nameEQ) === 0) {
-      return c.substring(nameEQ.length, c.length);
-    }
+    while (c.charAt(0) === " ") c = c.substring(1);
+    if (c.indexOf(nameEQ) === 0) return c.substring(nameEQ.length);
   }
   return null;
 }
 
-async function submitExperimentUser(user_id, experiment_id, variant, appUrl) {
-  const collectUrl = `${appUrl}/api/collect`;
+async function submitExperimentUser(userId, experimentId, variantName, appUrl) {
   const payload = {
     event_type: "experiment_include",
-    client_id: user_id,
-    experiment_id: experiment_id,
-    variant: variant,
+    client_id: userId,
+    experiment_id: experimentId,
+    variant: variantName,
     timestamp: new Date().toISOString(),
   };
-  fetch(collectUrl, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json", // Indicate that the body is JSON
-    },
-    body: JSON.stringify(payload),
-  })
-    .then((res) => {
-      if (!res.ok) {
-        throw new Error("User not attributed to experiment");
-      }
-    })
-    .catch((error) => {
-      console.log(error);
+
+  try {
+    const res = await fetch(`${appUrl}/api/collect`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
     });
+    if (!res.ok) throw new Error("Server responded with " + res.status);
+  } catch (err) {
+    console.error(
+      "[ab-insightful] Failed to submit experiment inclusion:",
+      err,
+    );
+  }
 }


### PR DESCRIPTION
Summary
- Multi-variant experiment support: Merchants can now create and run experiments with up to 5 total variants (Control + up to 4 variants). Each variant has its own Section ID and configurable traffic allocation percentage that must sum to 100%.
- End-to-end a/b/c/n variant support: The storefront embed script uses weighted random selection to assign visitors across N variants, persists assignments in cookies, and correctly tracks allocations/conversions per variant. The createExperiment API, frontend API endpoint, experiment create/edit pages, reports page, and home dashboard all support the new multi-variant data model.
- Reports updated for N variants: The report page now identifies the Control variant by name (not array index), supports detecting multiple simultaneous winners, renders all variant rows with correct color-coded metrics, and graphs probability-to-be-best and expected loss for any number of variants.
- Testing: Added test code for each added function and surrounding elements in an attempt to increase total testing % completion. 