### PR TITLE
Device Type bug fix, Separate integration implemented

### DIFF
--- a/app/__tests__/api.collect.integration.test.js
+++ b/app/__tests__/api.collect.integration.test.js
@@ -1,0 +1,142 @@
+// @vitest-environment node
+
+import { beforeEach, afterAll, describe, expect, it } from "vitest";
+import { Prisma } from "@prisma/client";
+import db from "../db.server";
+import { action } from "../routes/api.collect.jsx";
+
+async function waitFor(fn, { timeoutMs = 2000, intervalMs = 50 } = {}) {
+  const start = Date.now();
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const val = await fn();
+    if (val) return val;
+    if (Date.now() - start > timeoutMs) return null;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+}
+
+describe("api.collect route integration", () => {
+  beforeEach(async () => {
+    await db.allocation.deleteMany();
+    await db.conversion.deleteMany();
+    await db.user.deleteMany();
+
+    await db.variant.deleteMany({
+      where: {
+        experimentId: 8882,
+      },
+    });
+
+    await db.experiment.deleteMany({
+      where: {
+        id: 8882,
+      },
+    });
+
+    await db.project.deleteMany({
+      where: {
+        id: 8881,
+      },
+    });
+
+    await db.project.create({
+      data: {
+        id: 8881,
+        shop: "route-integration-test-shop.myshopify.com",
+        name: "Route Integration Test Project",
+      },
+    });
+
+    await db.experiment.create({
+      data: {
+        id: 8882,
+        name: "Route Integration Test Experiment",
+        description: "Testing api.collect action",
+        status: "active",
+        trafficSplit: new Prisma.Decimal(1),
+        sectionId: "section-route",
+        projectId: 8881,
+        variants: {
+          create: [
+            {
+              id: 8883,
+              name: "Control",
+              trafficAllocation: new Prisma.Decimal(1),
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("accepts POST and triggers experiment_include pipeline", async () => {
+    const payload = {
+      event_type: "experiment_include",
+      client_id: "route-test-user",
+      experiment_id: 8882,
+      experimentId: 8882,
+      variant: "Control",
+      device_type: "mobile",
+      timestamp: "2026-03-04T09:00:00.000Z",
+    };
+
+    const request = new Request("http://localhost/api/collect", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const response = await action({ request });
+
+    expect(response.status).toBe(200);
+
+    const body = await response.json();
+    expect(body).toBeNull();
+
+    const user = await waitFor(
+        () =>
+            db.user.findUnique({
+            where: { shopifyCustomerID: "route-test-user" },
+            }),
+        { timeoutMs: 2000, intervalMs: 50 },
+        );
+
+        expect(user).toBeTruthy();
+    expect(user.id).toBe("route-test-user");
+
+    const allocation = await waitFor(
+    () =>
+        db.allocation.findUnique({
+        where: {
+            userId_experimentId: {
+            userId: "route-test-user",
+            experimentId: 8882,
+            },
+        },
+        }),
+    { timeoutMs: 2000, intervalMs: 50 },
+    );
+
+    expect(allocation).toBeTruthy();
+    expect(allocation.variantId).toBe(8883);
+    expect(allocation.deviceType).toBe("mobile");
+  });
+
+  it("handles OPTIONS preflight", async () => {
+    const request = new Request("http://localhost/api/collect", {
+      method: "OPTIONS",
+    });
+
+    const response = await action({ request });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+  });
+});

--- a/app/__tests__/api.collect.route.test.js
+++ b/app/__tests__/api.collect.route.test.js
@@ -1,0 +1,135 @@
+// @vitest-environment node
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../services/experiment.server", () => ({
+  handleCollectedEvent: vi.fn(),
+}));
+
+import { handleCollectedEvent } from "../services/experiment.server";
+import { loader, action } from "../routes/api.collect.jsx";
+
+describe("api.collect route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("loader", () => {
+    it("returns 204 for OPTIONS with CORS headers", async () => {
+      const request = new Request("http://localhost/api/collect", {
+        method: "OPTIONS",
+      });
+
+      const response = await loader({ request });
+
+      expect(response.status).toBe(204);
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("POST, OPTIONS");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Content-Type");
+    });
+
+    it("returns null for non-OPTIONS requests", async () => {
+      const request = new Request("http://localhost/api/collect", {
+        method: "GET",
+      });
+
+      const response = await loader({ request });
+
+      expect(response).toBeNull();
+    });
+  });
+
+  describe("action", () => {
+    it("returns 204 for OPTIONS with CORS headers", async () => {
+      const request = new Request("http://localhost/api/collect", {
+        method: "OPTIONS",
+      });
+
+      const response = await action({ request });
+
+      expect(response.status).toBe(204);
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("POST, OPTIONS");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Content-Type");
+
+      expect(handleCollectedEvent).not.toHaveBeenCalled();
+    });
+
+    it("parses POST json, calls handleCollectedEvent, and returns 200 null", async () => {
+      const payload = {
+        event_type: "experiment_include",
+        client_id: "route-test-user",
+        experiment_id: 2001,
+        experimentId: 2001,
+        variant: "Control",
+        device_type: "mobile",
+        timestamp: "2026-03-04T09:00:00.000Z",
+      };
+
+      const request = new Request("http://localhost/api/collect", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const response = await action({ request });
+
+      expect(handleCollectedEvent).toHaveBeenCalledTimes(1);
+      expect(handleCollectedEvent).toHaveBeenCalledWith(payload);
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+      expect(response.headers.get("Access-Control-Allow-Methods")).toBe("POST, OPTIONS");
+      expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Content-Type");
+
+      const body = await response.json();
+      expect(body).toBeNull();
+    });
+
+    it("still returns 200 even if handleCollectedEvent rejects later because it is not awaited", async () => {
+      handleCollectedEvent.mockRejectedValueOnce(new Error("background failure"));
+
+      const payload = {
+        event_type: "experiment_include",
+        client_id: "route-test-user-2",
+        experiment_id: 2001,
+        experimentId: 2001,
+        variant: "Control",
+        device_type: "desktop",
+        timestamp: "2026-03-04T09:05:00.000Z",
+      };
+
+      const request = new Request("http://localhost/api/collect", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const response = await action({ request });
+
+      expect(handleCollectedEvent).toHaveBeenCalledTimes(1);
+      expect(handleCollectedEvent).toHaveBeenCalledWith(payload);
+      expect(response.status).toBe(200);
+
+      const body = await response.json();
+      expect(body).toBeNull();
+    });
+
+    it("throws when POST body is invalid JSON", async () => {
+      const request = new Request("http://localhost/api/collect", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: "{ not valid json",
+      });
+
+      await expect(action({ request })).rejects.toThrow();
+      expect(handleCollectedEvent).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/__tests__/api.collect.unit.test.js
+++ b/app/__tests__/api.collect.unit.test.js
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../services/experiment.server", () => ({
+  handleCollectedEvent: vi.fn(),
+}));
+
+import { handleCollectedEvent } from "../services/experiment.server";
+import { action } from "../routes/api.collect.jsx";
+
+describe("api.collect action", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("parses JSON, calls handleCollectedEvent, and returns 200", async () => {
+    const payload = {
+      event_type: "experiment_include",
+      client_id: "test123",
+      experiment_id: 2001,
+      experimentId: 2001,
+      variant: "Control",
+      device_type: "mobile",
+      timestamp: "2026-03-04T08:20:00.000Z",
+    };
+
+    const request = new Request("http://localhost/api/collect", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const response = await action({ request });
+
+    expect(handleCollectedEvent).toHaveBeenCalledTimes(1);
+    expect(handleCollectedEvent).toHaveBeenCalledWith(payload);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+
+    const body = await response.json();
+    expect(body).toBeNull();
+  });
+
+  it("handles OPTIONS preflight", async () => {
+    const request = new Request("http://localhost/api/collect", {
+      method: "OPTIONS",
+    });
+
+    const response = await action({ request });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("Access-Control-Allow-Origin")).toBe("*");
+    expect(handleCollectedEvent).not.toHaveBeenCalled();
+  });
+});

--- a/app/__tests__/experiment.collect.integration.test.js
+++ b/app/__tests__/experiment.collect.integration.test.js
@@ -1,0 +1,180 @@
+// @vitest-environment node
+
+import { beforeEach, afterAll, describe, expect, it } from "vitest";
+import { Prisma } from "@prisma/client";
+import db from "../db.server";
+import { handleCollectedEvent } from "../services/experiment.server";
+
+describe("handleCollectedEvent integration", () => {
+  beforeEach(async () => {
+    // clear runtime tables first
+    await db.allocation.deleteMany();
+    await db.conversion.deleteMany();
+    await db.user.deleteMany();
+
+    // clear only this test's fixed records
+    await db.variant.deleteMany({
+      where: {
+        experimentId: {
+          in: [9992, 9995],
+        },
+      },
+    });
+
+    await db.experiment.deleteMany({
+      where: {
+        id: {
+          in: [9992, 9995],
+        },
+      },
+    });
+
+    await db.project.deleteMany({
+      where: {
+        id: {
+          in: [9991, 9994],
+        },
+      },
+    });
+
+    // happy-path project/experiment/variant
+    await db.project.create({
+      data: {
+        id: 9991,
+        shop: "integration-test-shop.myshopify.com",
+        name: "Integration Test Project",
+      },
+    });
+
+    await db.experiment.create({
+      data: {
+        id: 9992,
+        name: "Integration Test Experiment",
+        description: "Testing experiment include pipeline",
+        status: "active",
+        trafficSplit: new Prisma.Decimal(1),
+        sectionId: "section-1",
+        projectId: 9991,
+        variants: {
+          create: [
+            {
+              id: 9993,
+              name: "Control",
+              trafficAllocation: new Prisma.Decimal(1),
+            },
+          ],
+        },
+      },
+    });
+
+    // failure-path project/experiment with NO matching Control variant
+    await db.project.create({
+      data: {
+        id: 9994,
+        shop: "integration-test-shop-2.myshopify.com",
+        name: "Integration Test Project Missing Variant",
+      },
+    });
+
+    await db.experiment.create({
+      data: {
+        id: 9995,
+        name: "Integration Test Experiment Missing Variant",
+        description: "Testing missing variant path",
+        status: "active",
+        trafficSplit: new Prisma.Decimal(1),
+        sectionId: "section-2",
+        projectId: 9994,
+        variants: {
+          create: [
+            {
+              id: 9996,
+              name: "Variant A",
+              trafficAllocation: new Prisma.Decimal(1),
+            },
+          ],
+        },
+      },
+    });
+  });
+
+  afterAll(async () => {
+    await db.$disconnect();
+  });
+
+  it("creates a user and allocation with deviceType from experiment_include", async () => {
+    const payload = {
+      event_type: "experiment_include",
+      client_id: "test123",
+      experiment_id: 9992,
+      experimentId: 9992,
+      variant: "Control",
+      device_type: "mobile",
+      timestamp: "2026-03-04T08:20:00.000Z",
+    };
+
+    const result = await handleCollectedEvent(payload);
+
+    expect(result).toBeTruthy();
+    expect(result).not.toEqual({ ignored: true });
+
+    const user = await db.user.findUnique({
+      where: {
+        shopifyCustomerID: "test123",
+      },
+    });
+
+    expect(user).toBeTruthy();
+    expect(user.id).toBe("test123");
+    expect(user.shopifyCustomerID).toBe("test123");
+
+    const allocation = await db.allocation.findUnique({
+      where: {
+        userId_experimentId: {
+          userId: "test123",
+          experimentId: 9992,
+        },
+      },
+    });
+
+    expect(allocation).toBeTruthy();
+    expect(allocation.userId).toBe("test123");
+    expect(allocation.experimentId).toBe(9992);
+    expect(allocation.variantId).toBe(9993);
+    expect(allocation.deviceType).toBe("mobile");
+  });
+
+  it("returns ignored and does not create an allocation when the variant is not found", async () => {
+    const payload = {
+      event_type: "experiment_include",
+      client_id: "missing-variant-user",
+      experiment_id: 9995,
+      experimentId: 9995,
+      variant: "Control",
+      device_type: "desktop",
+      timestamp: "2026-03-04T08:25:00.000Z",
+    };
+
+    const result = await handleCollectedEvent(payload);
+
+    expect(result).toEqual({ ignored: true });
+
+    const user = await db.user.findUnique({
+      where: {
+        shopifyCustomerID: "missing-variant-user",
+      },
+    });
+
+    expect(user).toBeTruthy();
+    expect(user.id).toBe("missing-variant-user");
+
+    const allocation = await db.allocation.findFirst({
+      where: {
+        userId: "missing-variant-user",
+        experimentId: 9995,
+      },
+    });
+
+    expect(allocation).toBeNull();
+  });
+});

--- a/app/__tests__/experiment.collect.test.js
+++ b/app/__tests__/experiment.collect.test.js
@@ -1,0 +1,189 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../db.server", () => ({
+  default: {
+    experiment: {
+      findUnique: vi.fn(),
+    },
+    user: {
+      upsert: vi.fn(),
+    },
+    variant: {
+      findFirst: vi.fn(),
+    },
+    allocation: {
+      upsert: vi.fn(),
+    },
+    goal: {
+      findFirst: vi.fn(),
+    },
+    conversion: {
+      upsert: vi.fn(),
+    },
+    analysis: {
+      findFirst: vi.fn(),
+      findMany: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}));
+
+import db from "../db.server";
+import { handleCollectedEvent } from "../services/experiment.server";
+import { ExperimentStatus } from "@prisma/client";
+
+describe("handleCollectedEvent", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("upserts a user and allocation for experiment_include", async () => {
+    const payload = {
+      event_type: "experiment_include",
+      client_id: "test123",
+      experiment_id: 2001,
+      experimentId: 2001,
+      variant: "Control",
+      device_type: "mobile",
+      timestamp: "2026-03-04T08:20:00.000Z",
+    };
+
+    db.experiment.findUnique.mockResolvedValue({
+      id: 2001,
+      status: ExperimentStatus.active,
+      startDate: null,
+      endDate: null,
+    });
+
+    db.user.upsert.mockResolvedValue({
+      id: "test123",
+      shopifyCustomerID: "test123",
+    });
+
+    db.variant.findFirst.mockResolvedValue({
+      id: 3001,
+      name: "Control",
+    });
+
+    db.allocation.upsert.mockResolvedValue({
+      id: 1,
+      userId: "test123",
+      experimentId: 2001,
+      variantId: 3001,
+      deviceType: "mobile",
+    });
+
+    const result = await handleCollectedEvent(payload);
+
+    expect(db.user.upsert).toHaveBeenCalledWith({
+      where: {
+        shopifyCustomerID: "test123",
+      },
+      update: {
+        latestSession: "2026-03-04T08:20:00.000Z",
+      },
+      create: {
+        id: "test123",
+        shopifyCustomerID: "test123",
+      },
+    });
+
+    expect(db.variant.findFirst).toHaveBeenCalledWith({
+      where: {
+        experimentId: 2001,
+        name: "Control",
+      },
+      select: {
+        id: true,
+        name: true,
+      },
+    });
+
+    expect(db.allocation.upsert).toHaveBeenCalledWith({
+      where: {
+        userId_experimentId: {
+          userId: "test123",
+          experimentId: 2001,
+        },
+      },
+      create: {
+        userId: "test123",
+        experimentId: 2001,
+        variantId: 3001,
+        deviceType: "mobile",
+      },
+      update: {
+        variantId: 3001,
+        deviceType: "mobile",
+      },
+    });
+
+    expect(result).toEqual({
+      result: {
+        result: {
+          id: 1,
+          userId: "test123",
+          experimentId: 2001,
+          variantId: 3001,
+          deviceType: "mobile",
+        },
+      },
+    });
+  });
+
+  it("returns ignored when experiment is inactive", async () => {
+    const payload = {
+      event_type: "experiment_include",
+      client_id: "test123",
+      experimentId: 2001,
+      experiment_id: 2001,
+      variant: "Control",
+      device_type: "mobile",
+      timestamp: "2026-03-04T08:20:00.000Z",
+    };
+
+    db.experiment.findUnique.mockResolvedValue({
+      id: 2001,
+      status: ExperimentStatus.paused,
+      startDate: null,
+      endDate: null,
+    });
+
+    const result = await handleCollectedEvent(payload);
+
+    expect(result).toEqual({ ignored: true });
+    expect(db.user.upsert).not.toHaveBeenCalled();
+    expect(db.allocation.upsert).not.toHaveBeenCalled();
+  });
+
+  it("returns ignored when variant is not found", async () => {
+    const payload = {
+      event_type: "experiment_include",
+      client_id: "test123",
+      experimentId: 2001,
+      experiment_id: 2001,
+      variant: "Control",
+      device_type: "mobile",
+      timestamp: "2026-03-04T08:20:00.000Z",
+    };
+
+    db.experiment.findUnique.mockResolvedValue({
+      id: 2001,
+      status: ExperimentStatus.active,
+      startDate: null,
+      endDate: null,
+    });
+
+    db.user.upsert.mockResolvedValue({
+      id: "test123",
+      shopifyCustomerID: "test123",
+    });
+
+    db.variant.findFirst.mockResolvedValue(null);
+
+    const result = await handleCollectedEvent(payload);
+
+    expect(result).toEqual({ ignored: true });
+    expect(db.allocation.upsert).not.toHaveBeenCalled();
+  });
+});

--- a/app/services/cookie.server.js
+++ b/app/services/cookie.server.js
@@ -42,12 +42,11 @@ export async function updateLatestSession(userdata) {
     where: {
       shopifyCustomerID: userdata.client_id,
     },
-    update: {
-      latestSession: userdata.timestamp,
-    },
+    update: {},
     create: {
       shopifyCustomerID: userdata.client_id,
-      deviceType: userdata.device_type,
+      latestSession: new Date(userdata.latestSession),
+      deviceType: userdata.deviceType ?? null,
     },
   });
   return result;

--- a/app/services/experiment.server.js
+++ b/app/services/experiment.server.js
@@ -924,9 +924,11 @@ async function handleExperiment_IncludeEvent(payload) {
       userId: user.id,
       experimentId: payload.experiment_id,
       variantId: variant.id,
+      deviceType: payload.device_type ?? payload.deviceType ?? null,
     },
     update: {
       variantId: variant.id,
+      deviceType: payload.device_type ?? payload.deviceType ?? null,
     },
   });
   if (!result) {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "typecheck": "react-router typegen && tsc --noEmit",
     "test": "vitest run --coverage",
     "test:watch": "vitest",
+    "test:integration": "vitest run --config vitest.integration.config.js --coverage",
     "seed:dev": "node prisma/seed.js --environment=dev",
     "seed:test": "node prisma/seed.js --environment=test",
     "seed:demo": "node prisma/seed.js --environment=demo"

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -11,7 +11,11 @@ export default defineConfig({
             'src/**/*.test.{js,jsx}',
             'app/**/__tests__/**/*.{js,jsx}'
         ],
-        exclude: ['node_modules', 'dist'], // define directories to skip
+        exclude: [
+            'node_modules', 'dist',
+            'app/__tests__/experiment.collect.integration.test.js',
+            'app/__tests__/api.collect.integration.test.js',
+            "app/__tests__/api.collect.route.test.js",], // define directories to skip
         setupFiles: ['app/setupTests.js'], // define where the setup configuration is located
         css:true, 
         coverage: {

--- a/vitest.integration.config.js
+++ b/vitest.integration.config.js
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    globals: true,
+    include: [
+      "app/__tests__/experiment.collect.integration.test.js",
+      "app/__tests__/api.collect.integration.test.js",
+      "app/__tests__/api.collect.route.test.js",
+    ],
+    exclude: ["node_modules", "dist"],
+    setupFiles: [],
+    silent: true,
+    coverage: {
+      provider: "v8",
+      reporter: ["text", "html", "lcov"],
+      reportsDirectory: "coverage/integration",
+      all: false,
+      include: [
+        "app/services/experiment.server.js",
+        "app/routes/api.collect.jsx",
+        "app/services/cookie.server.js",
+      ],
+    },
+  },
+});


### PR DESCRIPTION
Along with the bug fix for device type of a user not updating in our db I implemented additional testing to further increase our code coverage. 

**Key changes**
- Fixed deviceType bug in which deviceType was not appearing in allocation table
- Added unit tests for api.collect
- Added route integration tests to validate flow through api.collect
- Added service integration tests for handleCollectedEvent to verity that the experiment handling creates user and allocations in db
- Added dedicated integration Vitest config (node environment) with coverage reporting
- Script added to run the separate integration config: `npm run test:integration`

**Notes**

- run the demo seed or make sure that the db is seeded with an active experiment
- run `npm run test:integration`

All tests pass

<img width="1786" height="929" alt="image" src="https://github.com/user-attachments/assets/81e7d237-563f-4984-a54f-9ae82776779e" />

<img width="1501" height="1181" alt="image" src="https://github.com/user-attachments/assets/df30b387-fbd6-40ac-bc0c-00e2b0e8cc20" />

