### PR TITLE
Et 504 success toast popup on experiment creation

### DIFF
--- a/app/__tests__/experimentSuccessBanner.test.jsx
+++ b/app/__tests__/experimentSuccessBanner.test.jsx
@@ -1,0 +1,89 @@
+import { render, screen, fireEvent, waitFor, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import EditExperiment from "../routes/app.experiments.$id";
+import { useLoaderData, useSearchParams, useFetcher } from "react-router";
+
+// Cast hooks for control
+const mockedUseLoaderData = vi.mocked(useLoaderData);
+const mockedUseSearchParams = vi.mocked(useSearchParams);
+const mockedUseFetcher = vi.mocked(useFetcher);
+
+vi.mock("react-router", () => ({
+  useLoaderData: vi.fn(),
+  useSearchParams: vi.fn(),
+  useFetcher: vi.fn(),
+  useRevalidator: () => ({ revalidate: vi.fn() }),
+}));
+
+describe("ET-504: Success Banner & Lifecycle Actions", () => {
+  const mockLoaderData = {
+    shop: "emmanuel-store-67.myshopify.com",
+    appHandle: "ab-insightful-1",
+    experiment: { id: 9002, status: "draft" },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Re-initialize Globals so they aren't undefined
+    global.window.shopify = {
+      navigation: { navigate: vi.fn() },
+      toast: { show: vi.fn() },
+    };
+
+    Object.assign(navigator, {
+      clipboard: { writeText: vi.fn().mockImplementation(() => Promise.resolve()) },
+    });
+
+    mockedUseLoaderData.mockReturnValue(mockLoaderData);
+    mockedUseFetcher.mockReturnValue({ state: "idle", submit: vi.fn() });
+  });
+
+  it("renders the banner when isNewlyCreated query param is present", () => {
+    mockedUseSearchParams.mockReturnValue([new URLSearchParams("isNewlyCreated=true"), vi.fn()]);
+    render(<EditExperiment />);
+    expect(screen.getByText(/successfully created/i)).toBeInTheDocument();
+  });
+
+  it("cleans up the URL immediately using shopify.navigation.navigate", () => {
+    mockedUseSearchParams.mockReturnValue([new URLSearchParams("isNewlyCreated=true"), vi.fn()]);
+    render(<EditExperiment />);
+    expect(window.shopify.navigation.navigate).toHaveBeenCalledWith(
+      window.location.pathname, 
+      { replace: true }
+    );
+  });
+
+  it("copies absolute Admin URLs to clipboard", async () => {
+    mockedUseSearchParams.mockReturnValue([new URLSearchParams("isNewlyCreated=true"), vi.fn()]);
+    render(<EditExperiment />);
+    
+    const copyBtn = screen.getByText(/Copy Experiment Link/i);
+    fireEvent.click(copyBtn);
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      expect.stringContaining("https://admin.shopify.com/store/emmanuel-store-67/apps/ab-insightful-1")
+    );
+
+    await waitFor(() => {
+      expect(window.shopify.toast.show).toHaveBeenCalledWith("Experiment link copied!");
+    });
+  });
+
+  it("correctly cycles intents based on experiment status", () => {
+    mockedUseSearchParams.mockReturnValue([new URLSearchParams("isNewlyCreated=true"), vi.fn()]);
+    const submitMock = vi.fn();
+    mockedUseFetcher.mockReturnValue({ state: "idle", submit: submitMock });
+
+    // Set to Active status
+    mockedUseLoaderData.mockReturnValue({ ...mockLoaderData, experiment: { id: 9002, status: "active" } });
+    render(<EditExperiment />);
+    
+    // Scoping to the banner to avoid sidebar conflicts
+    const banner = screen.getByTitle("Experiment created").closest('s-banner');
+    const bannerPauseBtn = within(banner).getByRole('button', { name: /^Pause$/ });
+    
+    fireEvent.click(bannerPauseBtn);
+    expect(submitMock).toHaveBeenCalledWith({ intent: "pause" }, { method: "post" });
+  });
+});

--- a/app/routes/app.experiments.$id.jsx
+++ b/app/routes/app.experiments.$id.jsx
@@ -15,7 +15,7 @@ if (typeof window !== "undefined") {
 
 import { authenticate } from "../shopify.server";
 import { useFetcher, redirect, useLoaderData, useRevalidator, useSearchParams } from "react-router";
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo} from "react";
 import db from "../db.server";
 import { ExperimentStatus } from "@prisma/client";
 import { TimeSelect } from "../utils/timeSelect";
@@ -102,6 +102,8 @@ export const loader = async ({ params, request }) => {
   }
 
   return {
+    shop: session.shop, // e.g., "emmanuel-store.myshopify.com"
+    appHandle: process.env.SHOPIFY_APP_HANDLE || "ab-insightful-1",
     experiment: {
       id: experiment.id,
       status: experiment.status,
@@ -527,6 +529,13 @@ export const action = async ({ request, params }) => {
   }
 };
 
+// Statically Building the app's URL
+// Helper to derive store slug (e.g., 'emmanuel-store')
+const getAdminBaseUrl = (shop, handle) => {
+  const slug = shop.replace(".myshopify.com", "");
+  return `https://admin.shopify.com/store/${slug}/apps/${handle}`;
+};
+
 //--------------------------- client side ----------------------------------------
 
 
@@ -536,8 +545,12 @@ export default function EditExperiment() {
   const loaderData = useLoaderData();
   const revalidator = useRevalidator();
 
+  const {shop, appHandle, experiment} = loaderData; 
+  const adminBaseUrl = useMemo(() => getAdminBaseUrl(shop, appHandle), [shop, appHandle]);
+  const reportsURL = `${adminBaseUrl}/app/reports/${experiment.id}`;
+
   // useSearchParams to render the succesful creation of an experiment
-  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchParams] = useSearchParams();
   // Dedicated fetcher for the banner actions
   const bannerFetcher = useFetcher(); 
 
@@ -562,19 +575,20 @@ export default function EditExperiment() {
 
   const handleDismissBanner = () => setShowSuccessBanner(false);
 
-  // Clipboard functionality
-  const handleCopyExperimentLink = () => {
-    // Strips the ?isNewlyCreated flag so the link shared is "clean"
-    const cleanUrl = window.location.href.split('?')[0];
-    navigator.clipboard.writeText(cleanUrl);
-    // Optional: Add a Shopify Toast here for "Link Copied"
+ const copyToClipboard = async (text, successMsg) => {
+    try {
+      await navigator.clipboard.writeText(text);
+      window.shopify?.toast?.show(successMsg);
+    } catch (err) {
+      console.error("Failed to copy!", err);
+    }
   };
 
-  const handleCopyReportsLink = () => {
-    const reportsUrl = `${window.location.origin}/app/reports/${loaderData.experiment.id}`;
-    navigator.clipboard.writeText(reportsUrl);
-    // Optional: Add a Shopify Toast here for "Link Copied"
-  };
+  const handleCopyExperimentLink = () => 
+    copyToClipboard(`${adminBaseUrl}/app/experiments/${experiment.id}`, "Experiment link copied!");
+
+  const handleCopyReportsLink = () => 
+    copyToClipboard(reportsURL, "Report link copied!");
 
   // allowable edits
   const status = loaderData?.experiment?.status;
@@ -1060,16 +1074,29 @@ export default function EditExperiment() {
                 <s-button variant="secondary" onClick={handleCopyReportsLink}>
                   Copy Reports Link
                 </s-button>
-                <s-button variant="secondary" href={`/app/reports/${loaderData.experiment.id}`}>
+                <s-button variant="secondary" href={reportsURL}>
                   Navigate to Reports
                 </s-button>
                 {/* Start Experiment */}
-                {status === ExperimentStatus.draft && (
+                {(status === ExperimentStatus.draft || status === ExperimentStatus.active || status === ExperimentStatus.paused) && (
                   <s-button 
-                    variant="primary"
-                    onClick={() => bannerFetcher.submit({ intent: "start" }, { method: "post" })}
+                    variant={status === ExperimentStatus.draft ? "primary" : "secondary"}
+                    disabled={bannerFetcher.state !== "idle"}
+                    onClick={() => {
+                      let intent = "start";
+                      if (status === ExperimentStatus.active) intent = "pause";
+                      if (status === ExperimentStatus.paused) intent = "resume";
+                      bannerFetcher.submit({ intent }, { method: "post" });
+                    }}
                     >
-                      {bannerFetcher.state === "submitting" ? "Starting...": "Start Experiment"}
+                      {bannerFetcher.state === "submitting" 
+                      ? "Updating..." 
+                      : status === ExperimentStatus.draft
+                        ? "Start Experiment"
+                        : status === ExperimentStatus.active
+                          ? "Pause"
+                          : "Resume"
+                        }
                     </s-button>
                 )}
               </s-stack>

--- a/app/routes/app.experiments.$id.jsx
+++ b/app/routes/app.experiments.$id.jsx
@@ -14,7 +14,7 @@ if (typeof window !== "undefined") {
 }
 
 import { authenticate } from "../shopify.server";
-import { useFetcher, redirect, useLoaderData, useRevalidator } from "react-router";
+import { useFetcher, redirect, useLoaderData, useRevalidator, useSearchParams } from "react-router";
 import { useState, useEffect } from "react";
 import db from "../db.server";
 import { ExperimentStatus } from "@prisma/client";
@@ -536,6 +536,46 @@ export default function EditExperiment() {
   const loaderData = useLoaderData();
   const revalidator = useRevalidator();
 
+  // useSearchParams to render the succesful creation of an experiment
+  const [searchParams, setSearchParams] = useSearchParams();
+  // Dedicated fetcher for the banner actions
+  const bannerFetcher = useFetcher(); 
+
+  const [showSuccessBanner, setShowSuccessBanner] = useState(
+    searchParams.get("isNewlyCreated") === "true"
+  );
+
+  // Transient cleanup
+  useEffect(() => {
+    if (showSuccessBanner) {
+      // Functional equivalent of "consume and strip"
+      const cleanPath = window.location.pathname;
+      
+      // Official App Bridge 4+ way to replace history without a reload
+      if (window.shopify && window.shopify.navigation) {
+        window.shopify.navigation.navigate(cleanPath, { replace: true });
+      } else {
+        window.history.replaceState(null, "", cleanPath);
+      }
+    }
+  }, []); // Only runs once on mount
+
+  const handleDismissBanner = () => setShowSuccessBanner(false);
+
+  // Clipboard functionality
+  const handleCopyExperimentLink = () => {
+    // Strips the ?isNewlyCreated flag so the link shared is "clean"
+    const cleanUrl = window.location.href.split('?')[0];
+    navigator.clipboard.writeText(cleanUrl);
+    // Optional: Add a Shopify Toast here for "Link Copied"
+  };
+
+  const handleCopyReportsLink = () => {
+    const reportsUrl = `${window.location.origin}/app/reports/${loaderData.experiment.id}`;
+    navigator.clipboard.writeText(reportsUrl);
+    // Optional: Add a Shopify Toast here for "Link Copied"
+  };
+
   // allowable edits
   const status = loaderData?.experiment?.status;
   const isDraft = status === ExperimentStatus.draft;
@@ -1002,6 +1042,41 @@ export default function EditExperiment() {
 
   return (
     <s-page heading="Edit Experiment" variant="headingLg">
+      {/* Success Notification UI Component */}
+      { showSuccessBanner && (
+        <s-box paddingBlockend="base">
+          <s-banner
+          title="Experiment created"
+          tone="success"
+          onDismiss={handleDismissBanner}
+          >
+            <s-stack gap="small" direction="block">
+              <s-paragraph> Your experiment has been successfully created! </s-paragraph>
+              <s-stack direction="inline" gap="small">
+                {/*Clipboard logic*/}
+                <s-button variant="secondary" onClick={handleCopyExperimentLink}>
+                  Copy Experiment Link
+                </s-button>
+                <s-button variant="secondary" onClick={handleCopyReportsLink}>
+                  Copy Reports Link
+                </s-button>
+                <s-button variant="secondary" href={`/app/reports/${loaderData.experiment.id}`}>
+                  Navigate to Reports
+                </s-button>
+                {/* Start Experiment */}
+                {status === ExperimentStatus.draft && (
+                  <s-button 
+                    variant="primary"
+                    onClick={() => bannerFetcher.submit({ intent: "start" }, { method: "post" })}
+                    >
+                      {bannerFetcher.state === "submitting" ? "Starting...": "Start Experiment"}
+                    </s-button>
+                )}
+              </s-stack>
+            </s-stack>
+          </s-banner>
+        </s-box>
+      )}
       <s-button
         slot="primary-action"
         variant="primary"

--- a/app/routes/app.experiments.new.jsx
+++ b/app/routes/app.experiments.new.jsx
@@ -276,9 +276,11 @@ export const action = async ({ request }) => {
       variants: treatmentVariants,
     });
 
-    return redirect(`/app/experiments/${experiment.id}`);
-  }
-}; //end async action
+    return redirect(`/app/experiments/${experiment.id}?isNewlyCreated=true`);
+    }
+  }; //end async action
+
+  
 
 //pull the default goal stored in database, completedCheckout if empty
 export const loader = async ({ request }) => {


### PR DESCRIPTION
ET-504 Show success toast popup upon experiment creation

- Added a green success notification that triggers only upon redirect from the creation page via the `isNewlyCreated` query parameter.

- Integrated a `useEffect` hook that uses `window.shopify.navigation` to strip the success flag from the URL immediately after rendering, preventing the banner from reappearing on manual refreshes.

- Refactored the "Copy Link" utilities to generate absolute admin.shopify.com URLs instead of internal tunnel links ( copy edit experiment page link & copy experiment reports page link )

- Integrated a "Start/Pause/Resume" action button within the banner that dynamically updates its intent based on the experiment's current status.

- Implemented a button that navigates to the experiment's report page

<img width="1627" height="789" alt="image" src="https://github.com/user-attachments/assets/54caabc7-31e2-4ab8-9ee5-28e20da66254" />
