### PR TITLE
ET-563 Icon Renders Proper Size

### DIFF
--- a/app/__tests__/sectionIdTruncation.test.js
+++ b/app/__tests__/sectionIdTruncation.test.js
@@ -1,0 +1,30 @@
+//check if the sectionId in the side pannel of create experiment and edit experiment
+//are cut down to 30 characters (so that icon can render at proper size)
+import { describe, it, expect } from 'vitest';
+
+const truncateSectionId = (sectionId) =>
+  sectionId
+    ? sectionId.slice(0, 30) + (sectionId.length > 30 ? '...' : '')
+    : 'Section not selected';
+
+describe('variant sectionId truncation', () => {
+  it('truncates a sectionId longer than 30 characters and appends ellipsis', () => {
+    const longId = 'shopify-section-template--20293268209888__hero-_jVaWmY';
+    expect(truncateSectionId(longId)).toBe('shopify-section-template--2029...');
+  });
+
+  it('does not append ellipsis when sectionId is exactly 30 characters', () => {
+    const exactId = 'shopify-section-template--2029';
+    expect(truncateSectionId(exactId)).toBe(exactId);
+  });
+
+  it('does not truncate sectionId under 30 characters', () => {
+    const shortId = 'short-section-id';
+    expect(truncateSectionId(shortId)).toBe(shortId);
+  });
+
+  it('returns "Section not selected" when sectionId is falsy', () => {
+    expect(truncateSectionId('')).toBe('Section not selected');
+    expect(truncateSectionId(null)).toBe('Section not selected');
+  });
+});

--- a/app/routes/app.experiments.$id.jsx
+++ b/app/routes/app.experiments.$id.jsx
@@ -1143,7 +1143,7 @@ export default function EditExperiment() {
                 icon={v.sectionId ? "code" : "alert-circle"}
               >
                 Variant {VARIANT_LABELS[i]}:{" "}
-                {v.sectionId || "Section not selected"}
+                {v.sectionId ? v.sectionId.slice(0, 30) + (v.sectionId.length > 30 ? "..." : "") : "Section not selected"}
               </s-badge>
             ))}
 

--- a/app/routes/app.experiments.new.jsx
+++ b/app/routes/app.experiments.new.jsx
@@ -861,7 +861,7 @@ export default function CreateExperiment() {
                 icon={v.sectionId ? "code" : "alert-circle"}
               >
                 Variant {VARIANT_LABELS[i]}:{" "}
-                {v.sectionId || "Section not selected"}
+                {v.sectionId ? v.sectionId.slice(0, 30) + (v.sectionId.length > 30 ? "..." : "") : "Section not selected"}
               </s-badge>
             ))}
 


### PR DESCRIPTION
On the create experiment page, the "code" icon next to the experiment variant section ID was rendering too small.  This bugfix addresses that, letting it render at the proper size
To test:
-Create/Edit experiment page
-Ensure you have an ID selected
-Check the icon in the quick access bar (should be full size)