### PR TITLE
Et 565 end condition registers&functionality is completed

### DIFF
--- a/app/__tests__/analysis.server.test.js
+++ b/app/__tests__/analysis.server.test.js
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createAnalysisSnapshot } from "../services/analysis.server";
+import db from "../db.server";
+import * as experimentService from "../services/experiment.server";
+
+// Mock the database
+vi.mock("../db.server", () => ({
+  default: {
+    experiment: { findMany: vi.fn() },
+    allocation: { groupBy: vi.fn() },
+    conversion: { groupBy: vi.fn() },
+    analysis: { 
+      createMany: vi.fn(), 
+      findFirst: vi.fn() 
+    },
+  },
+}));
+
+// Mock the experiment service functions
+vi.mock("../services/experiment.server", () => ({
+  setProbabilityOfBest: vi.fn(),
+  endExperiment: vi.fn(),
+}));
+
+describe("analysis.server.js -> createAnalysisSnapshot()", () => {
+  
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should complete the full pipeline: aggregate data, save rows, and evaluate termination", async () => {
+    
+    // Mock 1 Active Experiment
+    db.experiment.findMany.mockResolvedValue([{
+      id: 9110,
+      startDate: new Date("2026-03-10"),
+      endCondition: "stableSuccessProbability",
+      probabilityToBeBest: 80,
+      variants: [{ id: 101 }],
+      experimentGoals: [{ goalId: 501 }]
+    }]);
+
+    // Mock Allocation (100 users) and Conversion (50 users)
+    db.allocation.groupBy.mockResolvedValue([
+      { experimentId: 9110, variantId: 101, deviceType: "desktop", _count: { id: 100 } }
+    ]);
+    db.conversion.groupBy.mockResolvedValue([
+      { experimentId: 9110, variantId: 101, goalId: 501, deviceType: "desktop", _count: { id: 50 } }
+    ]);
+
+    // Mock the "Winning" result for the termination check
+    db.analysis.findFirst.mockResolvedValue({
+      probabilityOfBeingBest: 0.95 // 95% is > 80% target
+    });
+
+    await createAnalysisSnapshot();
+    
+    // 1. Check if it calculated the correct math for the DB save
+    expect(db.analysis.createMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.arrayContaining([
+          expect.objectContaining({
+            totalUsers: 100,
+            totalConversions: 50,
+            conversionRate: 0.5
+          })
+        ])
+      })
+    );
+
+    // 2. Check if the math engine was triggered
+    expect(experimentService.setProbabilityOfBest).toHaveBeenCalled();
+
+    // 3. Check if the Auto-Termination was triggered based on the 95% result
+    expect(experimentService.endExperiment).toHaveBeenCalledWith(9110);
+  });
+});

--- a/app/routes/app.experiments.new.jsx
+++ b/app/routes/app.experiments.new.jsx
@@ -52,7 +52,7 @@ export const action = async ({ request }) => {
     const description = (formData.get("description") || "").trim();
     const controlSectionId = (formData.get("controlSectionId") || "").trim();
     const goalValue = (formData.get("goal") || "").trim();
-    const endCondition = (formData.get("endCondition") || "").trim();
+    const endCondition = (formData.get("endCondition") || "manual").trim();
 
     let variantInputs;
     try {
@@ -1143,6 +1143,7 @@ export default function CreateExperiment() {
       {/*Active dates/end conditions portion of code */}
       <s-section heading="Active Dates">
         <s-form>
+        <input type="hidden" name="endCondition" value={endCondition} />
           <s-stack direction="block" gap="base">
             <s-stack direction="inline" gap="base">
               <s-box flex="1" minInlineSize="220px" inlineSize="stretch">

--- a/app/services/analysis.server.js
+++ b/app/services/analysis.server.js
@@ -178,5 +178,48 @@ export async function createAnalysisSnapshot() {
       }
     }
   }
+
+  // Evaluation & auto-termination of experiments
+  for (const exp of experiments) {
+    if (!exp.endCondition || exp.endCondition === "manual") continue;
+
+    let shouldTerminate = false;
+    const now = new Date();
+
+    // Evaluate end date termination criteria
+    if (terminationCriteria.endCondition === "endDate" && terminationCriteria.endDate) {
+      if (now >= new Date(terminationCriteria.endDate)) {
+        shouldTerminate = true;
+      }
+    }
+
+    // Evaluate probability to be best termination criteria
+    if (terminationCriteria.endCondition === "stableSuccessProbability") {
+      const latestResult = await db.analysis.findFirst({
+        where: {
+          experimentId: exp.id,
+          deviceSegment: "all",
+        },
+        orderBy: { calculatedWhen: "desc" },
+      });
+
+      if (latestResult && latestResult.probabilityOfBeingBest != null) {
+        const currentActual = latestResult.probabilityOfBeingBest * 100;
+        const targetThreshold = terminationCriteria.probabilityToBeBest || 80;
+
+        if (currentActual >= targetThreshold) {
+          shouldTerminate = true;
+        }
+      }
+    }
+    
+    if (shouldTerminate) {
+      const { endExperiment } = await import("./experiment.server");
+      await endExperiment(exp.id);
+
+      console.info(`[Auto-terimination] Experiment ${exp.id} closed via ${terminationCriteria.endCondition}.`);
+    }
+  }
+
   return ret;
 }

--- a/app/services/analysis.server.js
+++ b/app/services/analysis.server.js
@@ -217,8 +217,6 @@ export async function createAnalysisSnapshot() {
     if (shouldTerminate) {
       const { endExperiment } = await import("./experiment.server");
       await endExperiment(exp.id);
-
-      console.info(`[Auto-termination] Experiment ${exp.id} closed via ${exp.endCondition}.`);
     }
   }
 

--- a/app/services/analysis.server.js
+++ b/app/services/analysis.server.js
@@ -179,22 +179,23 @@ export async function createAnalysisSnapshot() {
     }
   }
 
-  // Evaluation & auto-termination of experiments
+  // 7. Evaluation & auto-termination of experiments
   for (const exp of experiments) {
+    // skip manual termination experiments/missing end condition
     if (!exp.endCondition || exp.endCondition === "manual") continue;
 
     let shouldTerminate = false;
     const now = new Date();
 
     // Evaluate end date termination criteria
-    if (terminationCriteria.endCondition === "endDate" && terminationCriteria.endDate) {
-      if (now >= new Date(terminationCriteria.endDate)) {
+    if (exp.endCondition === "endDate" && exp.endDate) {
+      if (now >= new Date(exp.endDate)) {
         shouldTerminate = true;
       }
     }
 
     // Evaluate probability to be best termination criteria
-    if (terminationCriteria.endCondition === "stableSuccessProbability") {
+    if (exp.endCondition === "stableSuccessProbability") {
       const latestResult = await db.analysis.findFirst({
         where: {
           experimentId: exp.id,
@@ -205,7 +206,7 @@ export async function createAnalysisSnapshot() {
 
       if (latestResult && latestResult.probabilityOfBeingBest != null) {
         const currentActual = latestResult.probabilityOfBeingBest * 100;
-        const targetThreshold = terminationCriteria.probabilityToBeBest || 80;
+        const targetThreshold = exp.probabilityToBeBest || 80;
 
         if (currentActual >= targetThreshold) {
           shouldTerminate = true;
@@ -217,7 +218,7 @@ export async function createAnalysisSnapshot() {
       const { endExperiment } = await import("./experiment.server");
       await endExperiment(exp.id);
 
-      console.info(`[Auto-terimination] Experiment ${exp.id} closed via ${terminationCriteria.endCondition}.`);
+      console.info(`[Auto-termination] Experiment ${exp.id} closed via ${exp.endCondition}.`);
     }
   }
 


### PR DESCRIPTION
This PR closes the loop on the experiment lifecycle by implementing an automated termination engine. It ensures that experiments move from active to completed without manual intervention once user-defined criteria (Time or Statistical Probability) are met.


- Bug Fix in `Create Experiment` page. Injected a hidden input field into the Active Dates section of the creation form. This ensures the default manual state is included in the native FormData even if the user doesn't toggle the UI buttons.

- Updated the experiment creation action to safely fallback to manual, preventing null pointer issues in the database.

- `createAnalysisSnapshot` now determines if an experiment should end, and ends it based on its respective end condition.

- Automatically ends experiments if now >= endDate. Experiments are compared to the live probabilityOfBeingBest against the user's probabilityToBeBest (80% default otherwise) threshold.

NOTE: the stablesuccessprobability will experience a refactor in my next story, but it is acceptable in its current state as far as the AC is concerned for this story. 