### PR TITLE
Et 182 add max visitors

### DIFF
--- a/app/__tests__/api.collect.integration.test.js
+++ b/app/__tests__/api.collect.integration.test.js
@@ -4,17 +4,7 @@ import { beforeEach, afterAll, describe, expect, it } from "vitest";
 import { Prisma } from "@prisma/client";
 import db from "../db.server";
 import { action } from "../routes/api.collect.jsx";
-
-async function waitFor(fn, { timeoutMs = 2000, intervalMs = 50 } = {}) {
-  const start = Date.now();
-  // eslint-disable-next-line no-constant-condition
-  while (true) {
-    const val = await fn();
-    if (val) return val;
-    if (Date.now() - start > timeoutMs) return null;
-    await new Promise((r) => setTimeout(r, intervalMs));
-  }
-}
+import { handleCollectedEvent } from "../services/experiment.server";
 
 describe("api.collect route integration", () => {
   beforeEach(async () => {
@@ -100,30 +90,23 @@ describe("api.collect route integration", () => {
     const body = await response.json();
     expect(body).toBeNull();
 
-    const user = await waitFor(
-        () =>
-            db.user.findUnique({
-            where: { shopifyCustomerID: "route-test-user" },
-            }),
-        { timeoutMs: 2000, intervalMs: 50 },
-        );
+    // API uses fire-and-forget; run handleCollectedEvent directly to verify pipeline
+    await handleCollectedEvent(payload);
 
-        expect(user).toBeTruthy();
+    const user = await db.user.findUnique({
+      where: { shopifyCustomerID: "route-test-user" },
+    });
+    expect(user).toBeTruthy();
     expect(user.id).toBe("route-test-user");
 
-    const allocation = await waitFor(
-    () =>
-        db.allocation.findUnique({
-        where: {
-            userId_experimentId: {
-            userId: "route-test-user",
-            experimentId: 8882,
-            },
+    const allocation = await db.allocation.findUnique({
+      where: {
+        userId_experimentId: {
+          userId: "route-test-user",
+          experimentId: 8882,
         },
-        }),
-    { timeoutMs: 2000, intervalMs: 50 },
-    );
-
+      },
+    });
     expect(allocation).toBeTruthy();
     expect(allocation.variantId).toBe(8883);
     expect(allocation.deviceType).toBe("mobile");

--- a/app/__tests__/api.collect.integration.test.js
+++ b/app/__tests__/api.collect.integration.test.js
@@ -4,7 +4,6 @@ import { beforeEach, afterAll, describe, expect, it } from "vitest";
 import { Prisma } from "@prisma/client";
 import db from "../db.server";
 import { action } from "../routes/api.collect.jsx";
-import { handleCollectedEvent } from "../services/experiment.server";
 
 describe("api.collect route integration", () => {
   beforeEach(async () => {
@@ -88,10 +87,8 @@ describe("api.collect route integration", () => {
     expect(response.status).toBe(200);
 
     const body = await response.json();
-    expect(body).toBeNull();
-
-    // API uses fire-and-forget; run handleCollectedEvent directly to verify pipeline
-    await handleCollectedEvent(payload);
+    expect(body).toBeTruthy();
+    expect(body.result).toBeTruthy();
 
     const user = await db.user.findUnique({
       where: { shopifyCustomerID: "route-test-user" },

--- a/app/__tests__/api.collect.route.test.js
+++ b/app/__tests__/api.collect.route.test.js
@@ -55,7 +55,7 @@ describe("api.collect route", () => {
       expect(handleCollectedEvent).not.toHaveBeenCalled();
     });
 
-    it("parses POST json, calls handleCollectedEvent, and returns 200 null", async () => {
+    it("parses POST json, calls handleCollectedEvent, and returns 200 with result", async () => {
       const payload = {
         event_type: "experiment_include",
         client_id: "route-test-user",
@@ -65,6 +65,8 @@ describe("api.collect route", () => {
         device_type: "mobile",
         timestamp: "2026-03-04T09:00:00.000Z",
       };
+
+      handleCollectedEvent.mockResolvedValue({ result: { id: 1 } });
 
       const request = new Request("http://localhost/api/collect", {
         method: "POST",
@@ -85,10 +87,38 @@ describe("api.collect route", () => {
       expect(response.headers.get("Access-Control-Allow-Headers")).toBe("Content-Type");
 
       const body = await response.json();
-      expect(body).toBeNull();
+      expect(body).toEqual({ result: { id: 1 } });
     });
 
-    it("still returns 200 even if handleCollectedEvent rejects later because it is not awaited", async () => {
+    it("returns 200 with limitReached when experiment is at max users", async () => {
+      const payload = {
+        event_type: "experiment_include",
+        client_id: "route-test-user",
+        experiment_id: 2001,
+        experimentId: 2001,
+        variant: "Control",
+        device_type: "mobile",
+        timestamp: "2026-03-04T09:00:00.000Z",
+      };
+
+      handleCollectedEvent.mockResolvedValue({ result: { limitReached: true } });
+
+      const request = new Request("http://localhost/api/collect", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(payload),
+      });
+
+      const response = await action({ request });
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body).toEqual({ result: { limitReached: true } });
+    });
+
+    it("returns 500 when handleCollectedEvent throws", async () => {
       handleCollectedEvent.mockRejectedValueOnce(new Error("background failure"));
 
       const payload = {
@@ -113,10 +143,10 @@ describe("api.collect route", () => {
 
       expect(handleCollectedEvent).toHaveBeenCalledTimes(1);
       expect(handleCollectedEvent).toHaveBeenCalledWith(payload);
-      expect(response.status).toBe(200);
+      expect(response.status).toBe(500);
 
       const body = await response.json();
-      expect(body).toBeNull();
+      expect(body).toEqual({ error: "Event processing failed" });
     });
 
     it("throws when POST body is invalid JSON", async () => {

--- a/app/__tests__/createExperiment.test.js
+++ b/app/__tests__/createExperiment.test.js
@@ -145,4 +145,14 @@ describe("createExperiment", () => {
     expect(data.description).toBe("D");
     expect(data.endCondition).toBe("manual");
   });
+
+  it("stores maxUsers when provided (per-experiment override)", async () => {
+    await createExperiment(
+      { name: "With max", description: "desc", maxUsers: 5000 },
+      { variants: [{ sectionId: "a", trafficAllocation: 0.5 }] },
+    );
+
+    const data = db.experiment.create.mock.calls[0][0].data;
+    expect(data.maxUsers).toBe(5000);
+  });
 });

--- a/app/__tests__/experiment.collect.integration.test.js
+++ b/app/__tests__/experiment.collect.integration.test.js
@@ -16,7 +16,7 @@ describe("handleCollectedEvent integration", () => {
     await db.variant.deleteMany({
       where: {
         experimentId: {
-          in: [9992, 9995],
+          in: [9992, 9995, 9997],
         },
       },
     });
@@ -24,7 +24,7 @@ describe("handleCollectedEvent integration", () => {
     await db.experiment.deleteMany({
       where: {
         id: {
-          in: [9992, 9995],
+          in: [9992, 9995, 9997],
         },
       },
     });
@@ -91,6 +91,34 @@ describe("handleCollectedEvent integration", () => {
               id: 9996,
               name: "Variant A",
               trafficAllocation: new Prisma.Decimal(1),
+            },
+          ],
+        },
+      },
+    });
+
+    // max-users experiment: maxUsers=2, has Control + Variant A
+    await db.experiment.create({
+      data: {
+        id: 9997,
+        name: "Max Users Test Experiment",
+        description: "Testing max users enforcement",
+        status: "active",
+        trafficSplit: new Prisma.Decimal(0.5),
+        sectionId: "section-max",
+        projectId: 9991,
+        maxUsers: 2,
+        variants: {
+          create: [
+            {
+              id: 9998,
+              name: "Control",
+              trafficAllocation: new Prisma.Decimal(0.5),
+            },
+            {
+              id: 9999,
+              name: "Variant A",
+              trafficAllocation: new Prisma.Decimal(0.5),
             },
           ],
         },
@@ -176,5 +204,148 @@ describe("handleCollectedEvent integration", () => {
     });
 
     expect(allocation).toBeNull();
+  });
+
+  it("does not create new allocation when experiment is at max users", async () => {
+    // Allocate 2 users (maxUsers=2 for experiment 9997)
+    await handleCollectedEvent({
+      event_type: "experiment_include",
+      client_id: "max-user-1",
+      experiment_id: 9997,
+      experimentId: 9997,
+      variant: "Control",
+      device_type: "mobile",
+      timestamp: "2026-03-04T08:30:00.000Z",
+    });
+    await handleCollectedEvent({
+      event_type: "experiment_include",
+      client_id: "max-user-2",
+      experiment_id: 9997,
+      experimentId: 9997,
+      variant: "Variant A",
+      device_type: "desktop",
+      timestamp: "2026-03-04T08:31:00.000Z",
+    });
+
+    const countBefore = await db.allocation.count({
+      where: { experimentId: 9997 },
+    });
+    expect(countBefore).toBe(2);
+
+    // 3rd user should hit limit
+    const result = await handleCollectedEvent({
+      event_type: "experiment_include",
+      client_id: "max-user-3",
+      experiment_id: 9997,
+      experimentId: 9997,
+      variant: "Control",
+      device_type: "mobile",
+      timestamp: "2026-03-04T08:32:00.000Z",
+    });
+
+    expect(result?.result?.limitReached).toBe(true);
+
+    const countAfter = await db.allocation.count({
+      where: { experimentId: 9997 },
+    });
+    expect(countAfter).toBe(2);
+
+    const allocation3 = await db.allocation.findFirst({
+      where: {
+        userId: "max-user-3",
+        experimentId: 9997,
+      },
+    });
+    expect(allocation3).toBeNull();
+  });
+
+  it("allows existing users to update (e.g. variant change) when at max", async () => {
+    // Allocate 2 users (maxUsers=2)
+    await handleCollectedEvent({
+      event_type: "experiment_include",
+      client_id: "existing-update-1",
+      experiment_id: 9997,
+      experimentId: 9997,
+      variant: "Control",
+      device_type: "mobile",
+      timestamp: "2026-03-04T08:40:00.000Z",
+    });
+    await handleCollectedEvent({
+      event_type: "experiment_include",
+      client_id: "existing-update-2",
+      experiment_id: 9997,
+      experimentId: 9997,
+      variant: "Variant A",
+      device_type: "desktop",
+      timestamp: "2026-03-04T08:41:00.000Z",
+    });
+
+    // Existing user 1 sends another event with different variant - should update
+    const result = await handleCollectedEvent({
+      event_type: "experiment_include",
+      client_id: "existing-update-1",
+      experiment_id: 9997,
+      experimentId: 9997,
+      variant: "Variant A",
+      device_type: "desktop",
+      timestamp: "2026-03-04T08:42:00.000Z",
+    });
+
+    expect(result?.result?.limitReached).toBeUndefined();
+    expect(result?.result?.result).toBeTruthy();
+
+    const allocation = await db.allocation.findUnique({
+      where: {
+        userId_experimentId: {
+          userId: "existing-update-1",
+          experimentId: 9997,
+        },
+      },
+    });
+    expect(allocation).toBeTruthy();
+    expect(allocation.variantId).toBe(9999);
+    expect(allocation.deviceType).toBe("desktop");
+  });
+
+  it("uses experiment maxUsers override over project default", async () => {
+    // Experiment 9997 has maxUsers: 2 (override). Project 9991 has default 10000.
+    // First user gets allocation
+    await handleCollectedEvent({
+      event_type: "experiment_include",
+      client_id: "override-user-1",
+      experiment_id: 9997,
+      experimentId: 9997,
+      variant: "Control",
+      device_type: "mobile",
+      timestamp: "2026-03-04T08:50:00.000Z",
+    });
+    // Second user gets allocation
+    await handleCollectedEvent({
+      event_type: "experiment_include",
+      client_id: "override-user-2",
+      experiment_id: 9997,
+      experimentId: 9997,
+      variant: "Control",
+      device_type: "mobile",
+      timestamp: "2026-03-04T08:51:00.000Z",
+    });
+
+    const count = await db.allocation.count({
+      where: { experimentId: 9997 },
+    });
+    expect(count).toBe(2);
+
+    // Third user should be rejected (experiment maxUsers=2, not project 10000)
+    const result = await handleCollectedEvent({
+      event_type: "experiment_include",
+      client_id: "override-user-3",
+      experiment_id: 9997,
+      experimentId: 9997,
+      variant: "Control",
+      device_type: "mobile",
+      timestamp: "2026-03-04T08:52:00.000Z",
+    });
+
+    expect(result?.result?.limitReached).toBe(true);
   });
 });

--- a/app/__tests__/experiment.collect.test.js
+++ b/app/__tests__/experiment.collect.test.js
@@ -12,6 +12,10 @@ vi.mock("../db.server", () => ({
       findFirst: vi.fn(),
     },
     allocation: {
+      findUnique: vi.fn(),
+      count: vi.fn(),
+      create: vi.fn(),
+      update: vi.fn(),
       upsert: vi.fn(),
     },
     goal: {
@@ -25,6 +29,8 @@ vi.mock("../db.server", () => ({
       findMany: vi.fn(),
       update: vi.fn(),
     },
+    $executeRaw: vi.fn(),
+    $transaction: vi.fn((fn) => fn(db)),
   },
 }));
 
@@ -48,11 +54,20 @@ describe("handleCollectedEvent", () => {
       timestamp: "2026-03-04T08:20:00.000Z",
     };
 
+    const allocationResult = {
+      id: 1,
+      userId: "test123",
+      experimentId: 2001,
+      variantId: 3001,
+      deviceType: "mobile",
+    };
+
     db.experiment.findUnique.mockResolvedValue({
       id: 2001,
       status: ExperimentStatus.active,
       startDate: null,
       endDate: null,
+      project: { maxUsersPerExperiment: 10000 },
     });
 
     db.user.upsert.mockResolvedValue({
@@ -65,13 +80,11 @@ describe("handleCollectedEvent", () => {
       name: "Control",
     });
 
-    db.allocation.upsert.mockResolvedValue({
-      id: 1,
-      userId: "test123",
-      experimentId: 2001,
-      variantId: 3001,
-      deviceType: "mobile",
-    });
+    db.allocation.findUnique.mockResolvedValue(null);
+    db.allocation.count.mockResolvedValue(0);
+    db.allocation.create.mockResolvedValue(allocationResult);
+
+    db.$transaction.mockImplementation(async (fn) => fn(db));
 
     const result = await handleCollectedEvent(payload);
 
@@ -99,35 +112,13 @@ describe("handleCollectedEvent", () => {
       },
     });
 
-    expect(db.allocation.upsert).toHaveBeenCalledWith({
-      where: {
-        userId_experimentId: {
-          userId: "test123",
-          experimentId: 2001,
-        },
-      },
-      create: {
-        userId: "test123",
-        experimentId: 2001,
-        variantId: 3001,
-        deviceType: "mobile",
-      },
-      update: {
-        variantId: 3001,
-        deviceType: "mobile",
-      },
-    });
+    expect(db.allocation.findUnique).toHaveBeenCalled();
+    expect(db.allocation.count).toHaveBeenCalled();
+    expect(db.allocation.create).toHaveBeenCalled();
+    expect(db.allocation.upsert).not.toHaveBeenCalled();
 
     expect(result).toEqual({
-      result: {
-        result: {
-          id: 1,
-          userId: "test123",
-          experimentId: 2001,
-          variantId: 3001,
-          deviceType: "mobile",
-        },
-      },
+      result: { result: allocationResult },
     });
   });
 

--- a/app/__tests__/notificationSettingsCluster.test.js
+++ b/app/__tests__/notificationSettingsCluster.test.js
@@ -114,6 +114,121 @@ describe('app.settings action', () => {
   });
 
   // ------------------------------------------------------------------
+  //updateMaxUsersPerExperiment
+  // ------------------------------------------------------------------
+  describe('updateMaxUsersPerExperiment', () => {
+    it('saves valid integer to the database', async () => {
+      const request = makeRequest({
+        intent: 'updateMaxUsersPerExperiment',
+        maxUsersPerExperiment: '5000',
+      });
+      const result = await action({ request });
+
+      expect(db.project.update).toHaveBeenCalledWith({
+        where: { shop: 'test-shop.myshopify.com' },
+        data: { maxUsersPerExperiment: 5000 },
+      });
+      expect(result).toEqual({
+        ok: true,
+        intent: 'updateMaxUsersPerExperiment',
+        maxUsersPerExperiment: 5000,
+      });
+    });
+
+    it('accepts 1 as minimum value', async () => {
+      const request = makeRequest({
+        intent: 'updateMaxUsersPerExperiment',
+        maxUsersPerExperiment: '1',
+      });
+      const result = await action({ request });
+
+      expect(db.project.update).toHaveBeenCalledWith({
+        where: { shop: 'test-shop.myshopify.com' },
+        data: { maxUsersPerExperiment: 1 },
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('accepts 1,000,000 as maximum value', async () => {
+      const request = makeRequest({
+        intent: 'updateMaxUsersPerExperiment',
+        maxUsersPerExperiment: '1000000',
+      });
+      const result = await action({ request });
+
+      expect(db.project.update).toHaveBeenCalledWith({
+        where: { shop: 'test-shop.myshopify.com' },
+        data: { maxUsersPerExperiment: 1000000 },
+      });
+      expect(result.ok).toBe(true);
+    });
+
+    it('returns error when value is not a valid integer', async () => {
+      const request = makeRequest({
+        intent: 'updateMaxUsersPerExperiment',
+        maxUsersPerExperiment: 'abc',
+      });
+      const result = await action({ request });
+
+      expect(db.project.update).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        ok: false,
+        intent: 'updateMaxUsersPerExperiment',
+        error: 'Must be a valid integer',
+        field: 'maxUsersPerExperiment',
+      });
+    });
+
+    it('returns error when value is empty', async () => {
+      const request = makeRequest({
+        intent: 'updateMaxUsersPerExperiment',
+        maxUsersPerExperiment: '',
+      });
+      const result = await action({ request });
+
+      expect(db.project.update).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        ok: false,
+        intent: 'updateMaxUsersPerExperiment',
+        error: 'Must be a valid integer',
+        field: 'maxUsersPerExperiment',
+      });
+    });
+
+    it('returns error when value is less than 1', async () => {
+      const request = makeRequest({
+        intent: 'updateMaxUsersPerExperiment',
+        maxUsersPerExperiment: '0',
+      });
+      const result = await action({ request });
+
+      expect(db.project.update).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        ok: false,
+        intent: 'updateMaxUsersPerExperiment',
+        error: 'Must be at least 1',
+        field: 'maxUsersPerExperiment',
+      });
+    });
+
+    it('returns error when value exceeds 1,000,000', async () => {
+      const request = makeRequest({
+        intent: 'updateMaxUsersPerExperiment',
+        maxUsersPerExperiment: '1000001',
+      });
+      const result = await action({ request });
+
+      expect(db.project.update).not.toHaveBeenCalled();
+      expect(result).toEqual({
+        ok: false,
+        intent: 'updateMaxUsersPerExperiment',
+        error: 'Must be at most 1,000,000',
+        field: 'maxUsersPerExperiment',
+      });
+    });
+  });
+
+  // ------------------------------------------------------------------
   //disableNotifications
   // ------------------------------------------------------------------
   describe('disableNotifications', () => {

--- a/app/__tests__/validateMaxUsers.test.js
+++ b/app/__tests__/validateMaxUsers.test.js
@@ -1,0 +1,49 @@
+import { describe, it, expect } from "vitest";
+import { validateMaxUsers } from "../utils/validateMaxUsers";
+
+describe("validateMaxUsers", () => {
+  it("returns null when using account default", () => {
+    expect(validateMaxUsers(true, "")).toBeNull();
+    expect(validateMaxUsers(true, "abc")).toBeNull();
+    expect(validateMaxUsers(true, "5000")).toBeNull();
+  });
+
+  it("returns error when not using account default and value is empty", () => {
+    expect(validateMaxUsers(false, "")).toBe(
+      "Max users is required when not using account default",
+    );
+  });
+
+  it("returns error when value is not a whole number", () => {
+    expect(validateMaxUsers(false, "abc")).toBe(
+      "Max users must be a whole number",
+    );
+    expect(validateMaxUsers(false, "1.5")).toBe(
+      "Max users must be a whole number",
+    );
+  });
+
+  it("returns error when value is less than 1", () => {
+    expect(validateMaxUsers(false, "0")).toBe(
+      "Max users must be at least 1",
+    );
+    expect(validateMaxUsers(false, "-1")).toBe(
+      "Max users must be at least 1",
+    );
+  });
+
+  it("returns error when value exceeds 1,000,000", () => {
+    expect(validateMaxUsers(false, "1000001")).toBe(
+      "Max users must be at most 1,000,000",
+    );
+    expect(validateMaxUsers(false, "2000000")).toBe(
+      "Max users must be at most 1,000,000",
+    );
+  });
+
+  it("returns null for valid values", () => {
+    expect(validateMaxUsers(false, "1")).toBeNull();
+    expect(validateMaxUsers(false, "5000")).toBeNull();
+    expect(validateMaxUsers(false, "1000000")).toBeNull();
+  });
+});

--- a/app/routes/api.collect.jsx
+++ b/app/routes/api.collect.jsx
@@ -34,7 +34,9 @@ export const action = async ({ request }) => {
 
   // Don't await - need to return as possible // [ryan] I am assuming so we can service other events asap
   // but how do i surface the errors?
-  handleCollectedEvent(data);
+  Promise.resolve(handleCollectedEvent(data)).catch((err) =>
+    console.error("[api.collect] handleCollectedEvent error:", err),
+  );
 
   return Response.json(null, {
     status: 200,

--- a/app/routes/api.collect.jsx
+++ b/app/routes/api.collect.jsx
@@ -32,13 +32,25 @@ export const action = async ({ request }) => {
   const data = await request.json();
   console.log("Event happened:", data);
 
-  // Don't await - need to return as possible // [ryan] I am assuming so we can service other events asap
-  // but how do i surface the errors?
-  Promise.resolve(handleCollectedEvent(data)).catch((err) =>
-    console.error("[api.collect] handleCollectedEvent error:", err),
-  );
+  let result;
+  try {
+    result = await handleCollectedEvent(data);
+  } catch (err) {
+    console.error("[api.collect] handleCollectedEvent error:", err);
+    return Response.json(
+      { error: "Event processing failed" },
+      {
+        status: 500,
+        headers: {
+          "Access-Control-Allow-Origin": "*",
+          "Access-Control-Allow-Methods": "POST, OPTIONS",
+          "Access-Control-Allow-Headers": "Content-Type",
+        },
+      },
+    );
+  }
 
-  return Response.json(null, {
+  return Response.json(result ?? null, {
     status: 200,
     headers: {
       "Access-Control-Allow-Origin": "*",

--- a/app/routes/app.experiments.$id.jsx
+++ b/app/routes/app.experiments.$id.jsx
@@ -55,6 +55,14 @@ export const loader = async ({ params, request }) => {
     throw new Response("Experiment not found", { status: 404 });
   }
 
+  const userCount = await db.allocation.count({
+    where: { experimentId },
+  });
+  const effectiveMax =
+    experiment.maxUsers ??
+    experiment.project?.maxUsersPerExperiment ??
+    10000;
+
   // Convert dates to YYYY-MM-DD format and extract times
   const formatDate = (date) => {
     if (!date) return "";
@@ -125,6 +133,8 @@ export const loader = async ({ params, request }) => {
       timeUnit: experiment.timeUnit,
       maxUsers: experiment.maxUsers,
       maxUsersPerExperiment: experiment.project?.maxUsersPerExperiment ?? 10000,
+      userCount,
+      effectiveMax,
     },
   };
 };
@@ -1212,6 +1222,9 @@ export default function EditExperiment() {
               </s-text>
             ))}
             <s-text>• {controlAllocation}% Control</s-text>
+            <s-text>
+              • Users: {(experiment?.userCount ?? 0).toLocaleString()} / {(experiment?.effectiveMax ?? 10000).toLocaleString()}
+            </s-text>
             <s-text>
               • Active from{" "}
               {startDate

--- a/app/routes/app.experiments.$id.jsx
+++ b/app/routes/app.experiments.$id.jsx
@@ -21,6 +21,7 @@ import { ExperimentStatus } from "../utils/experimentConstants.js";
 import { TimeSelect } from "../utils/timeSelect";
 import { validateStartIsInFuture } from "../utils/validateStartIsInFuture";
 import { validateEndIsAfterStart } from "../utils/validateEndIsAfterStart";
+import { validateMaxUsers } from "../utils/validateMaxUsers";
 import { localDateTimeToISOString } from "../utils/localDateTimeToISOString";
 import { canRenameExperiment, isLockedStatus, canEditStructure, canEditSchedule, allowedStatusIntents, } from "./policies/experimentPolicy";
 
@@ -410,21 +411,8 @@ export const action = async ({ request, params }) => {
     }
   }
 
-  // Validate maxUsers when custom (not using account default)
-  if (!useAccountDefaultMaxUsers) {
-    if (!maxUsersStr) {
-      errors.maxUsers = "Max users is required when not using account default";
-    } else {
-      const parsed = Number(maxUsersStr);
-      if (!Number.isInteger(parsed)) {
-        errors.maxUsers = "Max users must be a whole number";
-      } else if (parsed < 1) {
-        errors.maxUsers = "Max users must be at least 1";
-      } else if (parsed > 1_000_000) {
-        errors.maxUsers = "Max users must be at most 1,000,000";
-      }
-    }
-  }
+  const maxUsersError = validateMaxUsers(useAccountDefaultMaxUsers, maxUsersStr);
+  if (maxUsersError) errors.maxUsers = maxUsersError;
 
   if (Object.keys(errors).length) return { errors };
 

--- a/app/routes/app.experiments.$id.jsx
+++ b/app/routes/app.experiments.$id.jsx
@@ -45,6 +45,9 @@ export const loader = async ({ params, request }) => {
         },
       },
       variants: true,
+      project: {
+        select: { maxUsersPerExperiment: true },
+      },
     },
   });
 
@@ -120,6 +123,8 @@ export const loader = async ({ params, request }) => {
       probabilityToBeBest: experiment.probabilityToBeBest,
       duration: experiment.duration,
       timeUnit: experiment.timeUnit,
+      maxUsers: experiment.maxUsers,
+      maxUsersPerExperiment: experiment.project?.maxUsersPerExperiment ?? 10000,
     },
   };
 };
@@ -266,6 +271,9 @@ export const action = async ({ request, params }) => {
   const durationStr = (formData.get("duration") || "").trim();
   const timeUnitValue = (formData.get("timeUnit") || "").trim();
 
+  const useAccountDefaultMaxUsers = formData.get("useAccountDefaultMaxUsers") === "true";
+  const maxUsersStr = (formData.get("maxUsers") || "").trim();
+
   let variantInputs;
   try {
     variantInputs = JSON.parse(formData.get("variantsJSON") || "[]");
@@ -392,6 +400,22 @@ export const action = async ({ request, params }) => {
     }
   }
 
+  // Validate maxUsers when custom (not using account default)
+  if (!useAccountDefaultMaxUsers) {
+    if (!maxUsersStr) {
+      errors.maxUsers = "Max users is required when not using account default";
+    } else {
+      const parsed = Number(maxUsersStr);
+      if (!Number.isInteger(parsed)) {
+        errors.maxUsers = "Max users must be a whole number";
+      } else if (parsed < 1) {
+        errors.maxUsers = "Max users must be at least 1";
+      } else if (parsed > 1_000_000) {
+        errors.maxUsers = "Max users must be at most 1,000,000";
+      }
+    }
+  }
+
   if (Object.keys(errors).length) return { errors };
 
   /* ====================================================================================================
@@ -431,6 +455,12 @@ export const action = async ({ request, params }) => {
       updateData.probabilityToBeBest = null;
       updateData.duration = null;
       updateData.timeUnit = null;
+    }
+
+    if (useAccountDefaultMaxUsers) {
+      updateData.maxUsers = null;
+    } else if (maxUsersStr) {
+      updateData.maxUsers = Number(maxUsersStr);
     }
   }
 
@@ -630,6 +660,9 @@ export default function EditExperiment() {
   const [endCondition, setEndCondition] = useState("manual");
   const [goalSelected, setGoalSelected] = useState("completedCheckout");
   const [customerSegment, setCustomerSegment] = useState("allSegments");
+  const [useAccountDefaultMaxUsers, setUseAccountDefaultMaxUsers] = useState(true);
+  const [maxUsers, setMaxUsers] = useState("");
+  const [maxUsersError, setMaxUsersError] = useState("");
   const [startDate, setStartDate] = useState("");
   const [startDateError, setStartDateError] = useState("");
   const [startTime, setStartTime] = useState("");
@@ -712,6 +745,14 @@ export default function EditExperiment() {
       setDuration(exp.duration || "");
       setTimeUnit(exp.timeUnit || "days");
 
+      if (exp.maxUsers != null) {
+        setUseAccountDefaultMaxUsers(false);
+        setMaxUsers(String(exp.maxUsers));
+      } else {
+        setUseAccountDefaultMaxUsers(true);
+        setMaxUsers("");
+      }
+
       if (exp.variants && exp.variants.length > 0) {
         setVariants(exp.variants);
         setVariantSectionErrors(exp.variants.map(() => null));
@@ -749,6 +790,8 @@ export default function EditExperiment() {
       !!errors.duration ||
       !!timeUnitError ||
       !!errors.timeUnit ||
+      !!maxUsersError ||
+      !!errors.maxUsers ||
       (canEditStartDateTime && (!!startDateError || !!errors.startDate || !!startTimeError)) ||
       !!emptyStartDateError ||
       (canEditEndCondition && (!!endDateError || !!errors.endDate || !!endTimeError || !!emptyEndDateError))
@@ -758,34 +801,41 @@ export default function EditExperiment() {
   const isSubmitting = fetcher.state === "submitting";
 
   const handleExperimentEdit = async () => {
-    const experimentData = renameOnlyMode ? { name: name } : (() => {
+    if (renameOnlyMode) {
+      try {
+        await fetcher.submit({ name: name }, { method: "POST" });
+      } catch (error) {
+        console.error("Error during fetcher.submit", error);
+      }
+      return;
+    }
 
-      const startDateUTC = startDate
-        ? localDateTimeToISOString(startDate, startTime)
-        : "";
-      const effectiveEndTime = endDate && !endTime ? "23:59" : endTime;
-      const endDateUTC = endDate
-        ? localDateTimeToISOString(endDate, effectiveEndTime)
-        : "";
+    const startDateUTC = startDate
+      ? localDateTimeToISOString(startDate, startTime)
+      : "";
+    const effectiveEndTime = endDate && !endTime ? "23:59" : endTime;
+    const endDateUTC = endDate
+      ? localDateTimeToISOString(endDate, effectiveEndTime)
+      : "";
 
-      return {
-        name: name,
-        description: description,
-        controlSectionId: controlSectionId,
-        variantsJSON: JSON.stringify(variants),
-        goal: goalSelected,
-        endCondition: endCondition,
-        startDateUTC: startDateUTC,
-        endDateUTC: endDateUTC,
-        endDate: endDate,
-        probabilityToBeBest: probabilityToBeBest,
-        duration: duration,
-        timeUnit: timeUnit,
-      };
-    })();
+    const formData = new FormData();
+    formData.set("name", name);
+    formData.set("description", description);
+    formData.set("controlSectionId", controlSectionId);
+    formData.set("variantsJSON", JSON.stringify(variants));
+    formData.set("goal", goalSelected);
+    formData.set("endCondition", endCondition);
+    formData.set("startDateUTC", startDateUTC);
+    formData.set("endDateUTC", endDateUTC);
+    formData.set("endDate", endDate);
+    formData.set("probabilityToBeBest", probabilityToBeBest);
+    formData.set("duration", duration);
+    formData.set("timeUnit", timeUnit);
+    formData.set("useAccountDefaultMaxUsers", String(useAccountDefaultMaxUsers));
+    formData.set("maxUsers", useAccountDefaultMaxUsers ? "" : String(maxUsers));
 
     try {
-      await fetcher.submit(experimentData, { method: "POST" });
+      await fetcher.submit(formData, { method: "POST" });
     } catch (error) {
       console.error("Error during fetcher.submit", error);
     }
@@ -1471,6 +1521,54 @@ export default function EditExperiment() {
               <s-option value="desktopVisitors">Desktop Visitors</s-option>
               <s-option value="mobileVisitors">Mobile Visitors</s-option>
             </s-select>
+
+            <s-checkbox
+              label="Use account default max users"
+              checked={useAccountDefaultMaxUsers}
+              disabled={isLocked || !editSchedule}
+              onChange={() => {
+                setUseAccountDefaultMaxUsers(!useAccountDefaultMaxUsers);
+                if (useAccountDefaultMaxUsers) {
+                  setMaxUsers(String(experiment.maxUsersPerExperiment ?? 10000));
+                } else {
+                  setMaxUsers("");
+                  setMaxUsersError("");
+                }
+              }}
+              details={`When enabled, uses the account default (${(experiment.maxUsersPerExperiment ?? 10000).toLocaleString()} users). Uncheck to set a custom max for this experiment.`}
+            />
+            {!useAccountDefaultMaxUsers && (
+              <s-number-field
+                label="Max users"
+                value={maxUsers}
+                inputMode="numeric"
+                min={1}
+                max={1000000}
+                step={1}
+                disabled={isLocked || !editSchedule}
+                error={maxUsersError || errors.maxUsers}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setMaxUsers(v);
+                  const num = Number(v);
+                  if (v === "" || v === null || v === undefined) {
+                    setMaxUsersError("Max users is required when not using account default");
+                  } else if (!Number.isInteger(num) || num < 1) {
+                    setMaxUsersError("Must be at least 1");
+                  } else if (num > 1000000) {
+                    setMaxUsersError("Must be at most 1,000,000");
+                  } else {
+                    setMaxUsersError("");
+                  }
+                }}
+                onBlur={() => {
+                  if (!useAccountDefaultMaxUsers && !maxUsers.trim()) {
+                    setMaxUsersError("Max users is required when not using account default");
+                  }
+                }}
+                details="Maximum number of users to include in this experiment. Leave account default checked to use your account setting."
+              />
+            )}
           </s-stack>
         </s-form>
       </s-section>

--- a/app/routes/app.experiments._index.jsx
+++ b/app/routes/app.experiments._index.jsx
@@ -7,6 +7,7 @@ import { ExperimentStatus } from "../utils/experimentConstants.js";
 import { allowedStatusIntents } from "./policies/experimentPolicy";
 import { usePagination } from "../hooks/usePagination";
 import Pagination from "../hooks/Pagination";
+import db from "../db.server";
 
 // Server side code
 
@@ -21,12 +22,22 @@ export async function loader() {
   const { getTutorialData } = await import ("../services/tutorialData.server");
   const tutorialData = await getTutorialData();
 
-  // compute improvements on the server
+  // compute improvements, user counts, and effective max on the server
   const enriched = await Promise.all(
-    experiments.map(async (e) => ({
-      ...e,
-      improvement: await getImprovement(e.id),
-    })),
+    experiments.map(async (e) => {
+      const [improvement, userCount] = await Promise.all([
+        getImprovement(e.id),
+        db.allocation.count({ where: { experimentId: e.id } }),
+      ]);
+      const effectiveMax =
+        e.maxUsers ?? e.project?.maxUsersPerExperiment ?? 10000;
+      return {
+        ...e,
+        improvement,
+        userCount,
+        effectiveMax,
+      };
+    }),
   );
 
   return {experiments: enriched, tutorialData }; // resolved data only
@@ -458,6 +469,9 @@ export default function Experimentsindex() {
           {/* displays N/A when data is null */}
           <s-table-cell>{renderStatus(curExp.status)}</s-table-cell>
           <s-table-cell> {runtime} </s-table-cell>
+          <s-table-cell>
+            {(curExp.userCount ?? 0).toLocaleString()} / {(curExp.effectiveMax ?? 10000).toLocaleString()}
+          </s-table-cell>
           <s-table-cell>N/A</s-table-cell>
           {/* Improvement Cell */}
           <s-table-cell>{formatImprovement(improvement)}</s-table-cell>
@@ -680,6 +694,7 @@ export default function Experimentsindex() {
                 <s-table-header listslot="primary">Name</s-table-header>
                 <s-table-header listSlot="secondary">Status</s-table-header>
                 <s-table-header listSlot="labeled">Runtime</s-table-header>
+                <s-table-header listSlot="labeled" format="numeric">Users</s-table-header>
                 <s-table-header listSlot="labeled" format="numeric">Goal Completion Rate</s-table-header>
                 <s-table-header listSlot="labeled" format="numeric">Improvement (%)</s-table-header>
                 <s-table-header listSlot="labeled" format="numeric">Probability to be the best</s-table-header>

--- a/app/routes/app.experiments.new.jsx
+++ b/app/routes/app.experiments.new.jsx
@@ -21,6 +21,7 @@ import { ExperimentStatus } from "../utils/experimentConstants.js";
 import { TimeSelect } from "../utils/timeSelect";
 import { validateStartIsInFuture } from "../utils/validateStartIsInFuture";
 import { validateEndIsAfterStart } from "../utils/validateEndIsAfterStart";
+import { validateMaxUsers } from "../utils/validateMaxUsers";
 import { localDateTimeToISOString } from "../utils/localDateTimeToISOString";
 
 // Server side code
@@ -185,21 +186,8 @@ export const action = async ({ request }) => {
       }
     }
 
-    // Validate maxUsers when custom (not using account default)
-    if (!useAccountDefaultMaxUsers) {
-      if (!maxUsersStr) {
-        errors.maxUsers = "Max users is required when not using account default";
-      } else {
-        const parsed = Number(maxUsersStr);
-        if (!Number.isInteger(parsed)) {
-          errors.maxUsers = "Max users must be a whole number";
-        } else if (parsed < 1) {
-          errors.maxUsers = "Max users must be at least 1";
-        } else if (parsed > 1_000_000) {
-          errors.maxUsers = "Max users must be at most 1,000,000";
-        }
-      }
-    }
+    const maxUsersError = validateMaxUsers(useAccountDefaultMaxUsers, maxUsersStr);
+    if (maxUsersError) errors.maxUsers = maxUsersError;
 
     if (Object.keys(errors).length) return { errors };
 

--- a/app/routes/app.experiments.new.jsx
+++ b/app/routes/app.experiments.new.jsx
@@ -72,6 +72,9 @@ export const action = async ({ request }) => {
     const durationStr = (formData.get("duration") || "").trim();
     const timeUnitValue = (formData.get("timeUnit") || "").trim();
 
+    const useAccountDefaultMaxUsers = formData.get("useAccountDefaultMaxUsers") === "true";
+    const maxUsersStr = (formData.get("maxUsers") || "").trim();
+
     // Date/Time Fields (accepts both client-side UTC strings or separate date/time fields)
     const startDateUTC = (formData.get("startDateUTC") || "").trim();
     const endDateUTC = (formData.get("endDateUTC") || "").trim();
@@ -182,6 +185,22 @@ export const action = async ({ request }) => {
       }
     }
 
+    // Validate maxUsers when custom (not using account default)
+    if (!useAccountDefaultMaxUsers) {
+      if (!maxUsersStr) {
+        errors.maxUsers = "Max users is required when not using account default";
+      } else {
+        const parsed = Number(maxUsersStr);
+        if (!Number.isInteger(parsed)) {
+          errors.maxUsers = "Max users must be a whole number";
+        } else if (parsed < 1) {
+          errors.maxUsers = "Max users must be at least 1";
+        } else if (parsed > 1_000_000) {
+          errors.maxUsers = "Max users must be at most 1,000,000";
+        }
+      }
+    }
+
     if (Object.keys(errors).length) return { errors };
 
     // Find or create a parent Project for this shop
@@ -265,6 +284,10 @@ export const action = async ({ request }) => {
       });
     }
 
+    if (!useAccountDefaultMaxUsers && maxUsersStr) {
+      experimentData.maxUsers = Number(maxUsersStr);
+    }
+
     const treatmentVariants = variantInputs.map((v) => ({
       sectionId: (v.sectionId || "").trim(),
       trafficAllocation: (v.trafficAllocation || 0) / 100.0,
@@ -287,7 +310,7 @@ export const loader = async ({ request }) => {
   const { session } = await authenticate.admin(request);
   const project = await db.project.findUnique({
     where: { shop: session.shop },
-    select: { defaultGoal: true },
+    select: { defaultGoal: true, maxUsersPerExperiment: true },
   });
 
   //looks up tutorial data
@@ -296,6 +319,7 @@ export const loader = async ({ request }) => {
 
   return {
     defaultGoal: project?.defaultGoal ?? "completedCheckout",
+    maxUsersPerExperiment: project?.maxUsersPerExperiment ?? 10000,
     tutorialData: tutorialInfo,
     shopDomain: session.shop, // provides shop domain for sectionId Picker Mode
   };
@@ -306,7 +330,7 @@ export const loader = async ({ request }) => {
 export default function CreateExperiment() {
   //fetcher stores the data in the fields into a form that can be retrieved
   const fetcher = useFetcher();
-  const { defaultGoal, tutorialData, shopDomain } = useLoaderData();
+  const { defaultGoal, maxUsersPerExperiment, tutorialData, shopDomain } = useLoaderData();
   const tutorialFetcher = useFetcher();
   const modalRef = useRef(null);
 
@@ -332,6 +356,9 @@ export default function CreateExperiment() {
   const [endCondition, setEndCondition] = useState("manual");
   const [goalSelected, setGoalSelected] = useState(defaultGoal);
   const [customerSegment, setCustomerSegment] = useState("allSegments");
+  const [useAccountDefaultMaxUsers, setUseAccountDefaultMaxUsers] = useState(true);
+  const [maxUsers, setMaxUsers] = useState("");
+  const [maxUsersError, setMaxUsersError] = useState("");
   const [startDate, setStartDate] = useState("");
   const [startDateError, setStartDateError] = useState("");
   const [startTime, setStartTime] = useState("");
@@ -454,6 +481,8 @@ export default function CreateExperiment() {
     !!errors.duration ||
     !!timeUnitError ||
     !!errors.timeUnit ||
+    !!maxUsersError ||
+    !!errors.maxUsers ||
     !!startDateError ||
     !!errors.startDate ||
     !!startTimeError ||
@@ -475,23 +504,24 @@ export default function CreateExperiment() {
       ? localDateTimeToISOString(endDate, effectiveEndTime)
       : "";
 
-    const experimentData = {
-      name: name,
-      description: description,
-      controlSectionId: controlSectionId,
-      variantsJSON: JSON.stringify(variants),
-      goal: goalSelected,
-      endCondition: endCondition,
-      startDateUTC: startDateUTC,
-      endDateUTC: endDateUTC,
-      endDate: endDate,
-      probabilityToBeBest: probabilityToBeBest,
-      duration: duration,
-      timeUnit: timeUnit,
-    };
+    const formData = new FormData();
+    formData.set("name", name);
+    formData.set("description", description);
+    formData.set("controlSectionId", controlSectionId);
+    formData.set("variantsJSON", JSON.stringify(variants));
+    formData.set("goal", goalSelected);
+    formData.set("endCondition", endCondition);
+    formData.set("startDateUTC", startDateUTC);
+    formData.set("endDateUTC", endDateUTC);
+    formData.set("endDate", endDate);
+    formData.set("probabilityToBeBest", probabilityToBeBest);
+    formData.set("duration", duration);
+    formData.set("timeUnit", timeUnit);
+    formData.set("useAccountDefaultMaxUsers", String(useAccountDefaultMaxUsers));
+    formData.set("maxUsers", useAccountDefaultMaxUsers ? "" : String(maxUsers));
 
     try {
-      await fetcher.submit(experimentData, { method: "POST" });
+      await fetcher.submit(formData, { method: "POST" });
     } catch (error) {
       console.error("Error during fetcher.submit", error);
     }
@@ -745,6 +775,9 @@ export default function CreateExperiment() {
     setControlSectionId("");
     setGoalSelected(defaultGoal);
     setCustomerSegment("allSegments");
+    setUseAccountDefaultMaxUsers(true);
+    setMaxUsers("");
+    setMaxUsersError("");
     setEndCondition("manual");
     setStartDate("");
     setStartTime("12:00");
@@ -1112,6 +1145,52 @@ export default function CreateExperiment() {
               <s-option value="desktopVisitors">Desktop Visitors</s-option>
               <s-option value="mobileVisitors">Mobile Visitors</s-option>
             </s-select>
+
+            <s-checkbox
+              label="Use account default max users"
+              checked={useAccountDefaultMaxUsers}
+              onChange={() => {
+                setUseAccountDefaultMaxUsers(!useAccountDefaultMaxUsers);
+                if (useAccountDefaultMaxUsers) {
+                  setMaxUsers(String(maxUsersPerExperiment ?? 10000));
+                } else {
+                  setMaxUsers("");
+                  setMaxUsersError("");
+                }
+              }}
+              details={`When enabled, uses the account default (${(maxUsersPerExperiment ?? 10000).toLocaleString()} users). Uncheck to set a custom max for this experiment.`}
+            />
+            {!useAccountDefaultMaxUsers && (
+              <s-number-field
+                label="Max users"
+                value={maxUsers}
+                inputMode="numeric"
+                min={1}
+                max={1000000}
+                step={1}
+                error={maxUsersError || errors.maxUsers}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  setMaxUsers(v);
+                  const num = Number(v);
+                  if (v === "" || v === null || v === undefined) {
+                    setMaxUsersError("Max users is required when not using account default");
+                  } else if (!Number.isInteger(num) || num < 1) {
+                    setMaxUsersError("Must be at least 1");
+                  } else if (num > 1000000) {
+                    setMaxUsersError("Must be at most 1,000,000");
+                  } else {
+                    setMaxUsersError("");
+                  }
+                }}
+                onBlur={() => {
+                  if (!useAccountDefaultMaxUsers && !maxUsers.trim()) {
+                    setMaxUsersError("Max users is required when not using account default");
+                  }
+                }}
+                details="Maximum number of users to include in this experiment. Leave account default checked to use your account setting."
+              />
+            )}
           </s-stack>
         </s-form>
       </s-section>

--- a/app/routes/app.reports.$id.jsx
+++ b/app/routes/app.reports.$id.jsx
@@ -113,6 +113,18 @@ export async function loader({ params, request }) {
     throw new Response("Experiment not found", {status: 404 });
   }
 
+  const experimentWithProject = await db.experiment.findUnique({
+    where: { id: experimentId },
+    include: { project: { select: { maxUsersPerExperiment: true } } },
+  });
+  const effectiveMax =
+    experimentWithProject?.maxUsers ??
+    experimentWithProject?.project?.maxUsersPerExperiment ??
+    10000;
+  const userCount = await db.allocation.count({
+    where: { experimentId },
+  });
+
   const {getImprovement} = await import("../services/experiment.server");
   const improvementPercent = await getImprovement(experimentId, deviceSegment);
 
@@ -155,7 +167,9 @@ export async function loader({ params, request }) {
   return { experiment:{ 
     ...experimentReportData,
     status: experimentInfo.status,
-    startDate: experimentInfo.startDate
+    startDate: experimentInfo.startDate,
+    userCount,
+    effectiveMax,
   },
   analysis,
   deviceSegment,
@@ -464,6 +478,9 @@ export default function Report() {
                 <s-badge icon="target">
                   {experiment.experimentGoals?.[0]?.goal?.name || "Primary Goal"}
                 </s-badge>
+                <s-text type="generic">
+                  Users: {(experiment.userCount ?? 0).toLocaleString()} / {(experiment.effectiveMax ?? 10000).toLocaleString()}
+                </s-text>
                 <s-text type="generic">Section ID: {experiment.sectionId}</s-text>
                 <s-text type="generic">
                   Started: {experiment.startDate ? new Date(experiment.startDate).toLocaleDateString() : 'Not yet started'}

--- a/app/routes/app.settings.jsx
+++ b/app/routes/app.settings.jsx
@@ -15,6 +15,7 @@ export const loader = async ({ request }) => {
       defaultGoal: true,
       enableExperimentStart: true,
       enableExperimentEnd: true,
+      maxUsersPerExperiment: true,
       contactEmails: { select: { id: true, email: true } },
       contactPhones: { select: { id: true, phoneNumber: true } },
     },
@@ -32,6 +33,7 @@ export const loader = async ({ request }) => {
     defaultGoal: project.defaultGoal,
     enableExperimentStart: project.enableExperimentStart,
     enableExperimentEnd: project.enableExperimentEnd,
+    maxUsersPerExperiment: project.maxUsersPerExperiment,
     contactEmails: project.contactEmails,
     contactPhones: project.contactPhones,
     tutorialData: tutorialInfo,
@@ -211,6 +213,25 @@ export const action = async ({ request }) => {
     return { ok: true, intent: "updateExperimentEnd" };
   }
 
+  if (intent === "updateMaxUsersPerExperiment") {
+    const raw = formData.get("maxUsersPerExperiment");
+    const parsed = raw === "" || raw === null ? NaN : parseInt(String(raw), 10);
+    if (Number.isNaN(parsed)) {
+      return { ok: false, intent: "updateMaxUsersPerExperiment", error: "Must be a valid integer", field: "maxUsersPerExperiment" };
+    }
+    if (!Number.isInteger(parsed) || parsed < 1) {
+      return { ok: false, intent: "updateMaxUsersPerExperiment", error: "Must be at least 1", field: "maxUsersPerExperiment" };
+    }
+    if (parsed > 1_000_000) {
+      return { ok: false, intent: "updateMaxUsersPerExperiment", error: "Must be at most 1,000,000", field: "maxUsersPerExperiment" };
+    }
+    await db.project.update({
+      where: { shop: session.shop },
+      data: { maxUsersPerExperiment: parsed },
+    });
+    return { ok: true, intent: "updateMaxUsersPerExperiment", maxUsersPerExperiment: parsed };
+  }
+
   if (intent === "disableNotifications") {
     await db.project.update({
       where: { shop: session.shop },
@@ -232,9 +253,10 @@ function formatPhone(digits) {
 }
 
 export default function Settings() {
-  const { defaultGoal, enableExperimentStart, enableExperimentEnd, contactEmails, contactPhones, tutorialData, emailNotifEnabled } = useLoaderData();
+  const { defaultGoal, enableExperimentStart, enableExperimentEnd, maxUsersPerExperiment, contactEmails, contactPhones, tutorialData, emailNotifEnabled } = useLoaderData();
   const fetcher = useFetcher();
   const goalFetcher = useFetcher();
+  const maxUsersFetcher = useFetcher();
   const notifFetcher = useFetcher();
   const tutorialFetcher = useFetcher(); // for tutorial actions
   const modalRef = useRef(null);
@@ -246,7 +268,10 @@ export default function Settings() {
   const [selectedExperimentStart, setEnableExperimentStart] = useState(enableExperimentStart ?? false);
   const [selectedExperimentEnd, setEnableExperimentEnd] = useState(enableExperimentEnd ?? false);
   const [savedDefaultGoal, setSavedDefaultGoal] = useState(defaultGoal);
+  const [maxUsersInput, setMaxUsersInput] = useState(String(maxUsersPerExperiment ?? 10000));
+  const [savedMaxUsers, setSavedMaxUsers] = useState(maxUsersPerExperiment ?? 10000);
   const [showGoalSaveSuccess, setShowGoalSaveSuccess] = useState(false);
+  const [showMaxUsersSaveSuccess, setShowMaxUsersSaveSuccess] = useState(false);
   const [showStartSaveSuccess, setShowStartSaveSuccess] = useState(false);
   const [showEndSaveSuccess, setShowEndSaveSuccess] = useState(false);
   const [isGoalSaveHovered, setIsGoalSaveHovered] = useState(false);
@@ -261,6 +286,9 @@ export default function Settings() {
 
   const hasPendingGoalChanges = selectedDefaultGoal !== savedDefaultGoal;
   const isSavingGoal = goalFetcher.state !== "idle";
+  const hasPendingMaxUsersChanges = maxUsersInput !== String(savedMaxUsers);
+  const isSavingMaxUsers = maxUsersFetcher.state !== "idle";
+  const maxUsersError = maxUsersFetcher.data?.field === "maxUsersPerExperiment" ? maxUsersFetcher.data.error : null;
 
   //notification toggle fields
   const [emailEnabled, setEmailEnabled] = useState(emailNotifEnabled);
@@ -299,6 +327,12 @@ export default function Settings() {
   }, [defaultGoal]);
 
   useEffect(() => {
+    const value = maxUsersPerExperiment ?? 10000;
+    setMaxUsersInput(String(value));
+    setSavedMaxUsers(value);
+  }, [maxUsersPerExperiment]);
+
+  useEffect(() => {
     setEnableExperimentStart(enableExperimentStart ?? false);
     setEnableExperimentEnd(enableExperimentEnd ?? false);
   }, [enableExperimentStart, enableExperimentEnd]);
@@ -314,6 +348,18 @@ export default function Settings() {
         setShowGoalSaveSuccess(true);
     }
   }, [goalFetcher.state, goalFetcher.data]);
+
+  useEffect(() => {
+    if (
+      maxUsersFetcher.state === "idle" &&
+      maxUsersFetcher.data?.ok &&
+      maxUsersFetcher.data?.intent === "updateMaxUsersPerExperiment"
+    ) {
+      setSavedMaxUsers(maxUsersFetcher.data.maxUsersPerExperiment);
+      setMaxUsersInput(String(maxUsersFetcher.data.maxUsersPerExperiment));
+      setShowMaxUsersSaveSuccess(true);
+    }
+  }, [maxUsersFetcher.state, maxUsersFetcher.data]);
 
   //notifications success popups
   useEffect(() => {
@@ -338,6 +384,12 @@ export default function Settings() {
     }
   }, [hasPendingGoalChanges]);
 
+  useEffect(() => {
+    if (hasPendingMaxUsersChanges) {
+      setShowMaxUsersSaveSuccess(false);
+    }
+  }, [hasPendingMaxUsersChanges]);
+
   //handler functions
   const handleAddEmail = () => {fetcher.submit({ intent: "addEmail", email: emailInput }, { method: "post" });};
   const handleDeleteEmail = (id) => {fetcher.submit({ intent: "deleteEmail", id: String(id) }, { method: "post" });};
@@ -348,6 +400,14 @@ export default function Settings() {
     if (!hasPendingGoalChanges || isSavingGoal) return;
     goalFetcher.submit(
       { intent: "updateDefaultGoal", defaultGoal: selectedDefaultGoal },
+      { method: "post" },
+    );
+  };
+
+  const handleSaveMaxUsersPerExperiment = () => {
+    if (!hasPendingMaxUsersChanges || isSavingMaxUsers) return;
+    maxUsersFetcher.submit(
+      { intent: "updateMaxUsersPerExperiment", maxUsersPerExperiment: maxUsersInput },
       { method: "post" },
     );
   };
@@ -556,39 +616,65 @@ export default function Settings() {
       {/*experiment configuration*/}
       <s-section heading="Experiment Configuration">
         <div>
-          <s-stack direction="block" gap="base">
-            <s-select
-              label="Select a new default goal for creating new experiments"
-              name="defaultGoal"
-              value={selectedDefaultGoal}
-              onChange={(e) => setSelectedDefaultGoal(e.target.value)}
-            >
-              <s-option value="completedCheckout">Completed Checkout</s-option>
-              <s-option value="viewPage">Viewed Page</s-option>
-              <s-option value="startCheckout">Started Checkout</s-option>
-              <s-option value="addToCart">Added Product to Cart</s-option>
-            </s-select>
-            <s-stack direction="inline" gap="small" alignItems="center">
-              <s-button
-                variant="primary"
-                disabled={!hasPendingGoalChanges || isSavingGoal}
-                onClick={handleSaveDefaultGoal}
-                onMouseEnter={() => setIsGoalSaveHovered(true)}
-                onMouseLeave={() => {
-                  setIsGoalSaveHovered(false);
-                  setIsGoalSavePressed(false);
-                }}
-                onMouseDown={() => setIsGoalSavePressed(true)}
-                onMouseUp={() => setIsGoalSavePressed(false)}
-                style={{
-                  opacity: isGoalSaveHovered ? "0.95" : "1",
-                  transform: isGoalSavePressed ? "translateY(1px)" : "translateY(0)",
-                  transition: "opacity 120ms ease, transform 120ms ease",
-                }}
+          <s-stack direction="block" gap="large">
+            <s-stack direction="block" gap="base">
+              <s-select
+                label="Select a new default goal for creating new experiments"
+                name="defaultGoal"
+                value={selectedDefaultGoal}
+                onChange={(e) => setSelectedDefaultGoal(e.target.value)}
               >
-                Save
-              </s-button>
-              {showGoalSaveSuccess ? <s-text tone="success">Save success!</s-text> : null}
+                <s-option value="completedCheckout">Completed Checkout</s-option>
+                <s-option value="viewPage">Viewed Page</s-option>
+                <s-option value="startCheckout">Started Checkout</s-option>
+                <s-option value="addToCart">Added Product to Cart</s-option>
+              </s-select>
+              <s-stack direction="inline" gap="small" alignItems="center">
+                <s-button
+                  variant="primary"
+                  disabled={!hasPendingGoalChanges || isSavingGoal}
+                  onClick={handleSaveDefaultGoal}
+                  onMouseEnter={() => setIsGoalSaveHovered(true)}
+                  onMouseLeave={() => {
+                    setIsGoalSaveHovered(false);
+                    setIsGoalSavePressed(false);
+                  }}
+                  onMouseDown={() => setIsGoalSavePressed(true)}
+                  onMouseUp={() => setIsGoalSavePressed(false)}
+                  style={{
+                    opacity: isGoalSaveHovered ? "0.95" : "1",
+                    transform: isGoalSavePressed ? "translateY(1px)" : "translateY(0)",
+                    transition: "opacity 120ms ease, transform 120ms ease",
+                  }}
+                >
+                  Save
+                </s-button>
+                {showGoalSaveSuccess ? <s-text tone="success">Save success!</s-text> : null}
+              </s-stack>
+            </s-stack>
+            <s-stack direction="block" gap="base">
+              <s-number-field
+                label="Maximum users per experiment (default)"
+                value={maxUsersInput}
+                onInput={(e) => setMaxUsersInput(e.target.value)}
+                onChange={(e) => setMaxUsersInput(e.target.value)}
+                min={1}
+                max={1000000}
+                step={1}
+                inputMode="numeric"
+                error={maxUsersError ?? undefined}
+                details="Default limit for new experiments. Can be overridden per experiment."
+              />
+              <s-stack direction="inline" gap="small" alignItems="center">
+                <s-button
+                  variant="primary"
+                  disabled={!hasPendingMaxUsersChanges || isSavingMaxUsers}
+                  onClick={handleSaveMaxUsersPerExperiment}
+                >
+                  Save
+                </s-button>
+                {showMaxUsersSaveSuccess ? <s-text tone="success">Save success!</s-text> : null}
+              </s-stack>
             </s-stack>
           </s-stack>
         </div>

--- a/app/services/experiment.server.js
+++ b/app/services/experiment.server.js
@@ -903,6 +903,8 @@ async function handleExperiment_IncludeEvent(payload) {
     );
     return null;
   }
+
+  // Create/update user first so it exists even when variant is not found
   const user = await db.user.upsert({
     where: {
       shopifyCustomerID: payload.client_id,
@@ -917,7 +919,6 @@ async function handleExperiment_IncludeEvent(payload) {
   });
 
   // Then, tie that user to the experiment
-  // First, get the variant ID from the variant name
   const variant = await getVariant(payload.experiment_id, payload.variant);
 
   if (!variant) {
@@ -930,26 +931,74 @@ async function handleExperiment_IncludeEvent(payload) {
     return;
   }
 
-  // Now create or update the allocation
-  // TODO seems like there needs to be more error handling with this result variable here.
-  const result = await db.allocation.upsert({
-    where: {
-      userId_experimentId: {
-        userId: user.id,
-        experimentId: payload.experiment_id,
-      },
-    },
-    create: {
-      userId: user.id,
-      experimentId: payload.experiment_id,
-      variantId: variant.id,
-      deviceType: payload.device_type ?? payload.deviceType ?? null,
-    },
-    update: {
-      variantId: variant.id,
-      deviceType: payload.device_type ?? payload.deviceType ?? null,
+  const experimentId =
+    typeof payload.experiment_id === "string"
+      ? parseInt(payload.experiment_id, 10)
+      : payload.experiment_id;
+  const deviceType = payload.device_type ?? payload.deviceType ?? null;
+
+  // Resolve effective max: experiment override when set, otherwise project default
+  const experiment = await db.experiment.findUnique({
+    where: { id: experimentId },
+    include: {
+      project: { select: { maxUsersPerExperiment: true } },
     },
   });
+  const effectiveMax =
+    experiment?.maxUsers ??
+    experiment?.project?.maxUsersPerExperiment ??
+    10000;
+
+  // Run allocation logic in a transaction to serialize count+create and avoid races.
+  const result = await db.$transaction(async (tx) => {
+    const existingAllocation = await tx.allocation.findUnique({
+      where: {
+        userId_experimentId: {
+          userId: user.id,
+          experimentId,
+        },
+      },
+    });
+
+    if (existingAllocation) {
+      return tx.allocation.update({
+        where: {
+          userId_experimentId: {
+            userId: user.id,
+            experimentId,
+          },
+        },
+        data: {
+          variantId: variant.id,
+          deviceType,
+        },
+      });
+    }
+
+    const count = await tx.allocation.count({
+      where: { experimentId },
+    });
+    if (count >= effectiveMax) {
+      return null;
+    }
+
+    return tx.allocation.create({
+      data: {
+        userId: user.id,
+        experimentId,
+        variantId: variant.id,
+        deviceType,
+      },
+    });
+  });
+
+  if (!result) {
+    console.log(
+      "[handle experiment include] max users reached, not creating allocation",
+    );
+    return { limitReached: true };
+  }
+
   if (!result) {
     console.log(
       "[handle experiment include] an error occurred while publishing the allocation",
@@ -961,7 +1010,7 @@ async function handleExperiment_IncludeEvent(payload) {
       result,
     );
   }
-  return { result: result }; // should probably return the result to the client in the body of the response.
+  return { result }; // should probably return the result to the client in the body of the response.
 }
 
 async function persistConversion(payload, Goal_Type) {

--- a/app/services/experiment.server.js
+++ b/app/services/experiment.server.js
@@ -169,6 +169,9 @@ export async function getExperimentsList() {
           variant: true, //this gets us the variant name (e.g., "Control", "Variant A")
         },
       },
+      project: {
+        select: { maxUsersPerExperiment: true },
+      },
     },
   });
 

--- a/app/services/experiment.server.js
+++ b/app/services/experiment.server.js
@@ -8,6 +8,7 @@ import { ExperimentStatus } from "@prisma/client";
 // Accepts an array of treatment variant objects, each with { sectionId, trafficAllocation }.
 // A Control variant is always created automatically with the remaining traffic.
 // Variant names are auto-generated: "Control", "Variant A", "Variant B", "Variant C", ...
+// experimentData may include optional maxUsers (integer); when present, overrides account default.
 export async function createExperiment(
   experimentData,
   { controlSectionId = "", variants = [] } = {},

--- a/app/utils/validateMaxUsers.js
+++ b/app/utils/validateMaxUsers.js
@@ -1,0 +1,23 @@
+/**
+ * Validates maxUsers for experiment create/update when not using account default.
+ * @param {boolean} useAccountDefault - When true, skips validation (uses account default).
+ * @param {string} maxUsersStr - Raw form value for maxUsers.
+ * @returns {string|null} Error message or null if valid.
+ */
+export function validateMaxUsers(useAccountDefault, maxUsersStr) {
+  if (useAccountDefault) return null;
+  if (!maxUsersStr) {
+    return "Max users is required when not using account default";
+  }
+  const parsed = Number(maxUsersStr);
+  if (!Number.isInteger(parsed)) {
+    return "Max users must be a whole number";
+  }
+  if (parsed < 1) {
+    return "Max users must be at least 1";
+  }
+  if (parsed > 1_000_000) {
+    return "Max users must be at most 1,000,000";
+  }
+  return null;
+}

--- a/extensions/ab-insightful-embed/assets/ab-insightful-embed.js
+++ b/extensions/ab-insightful-embed/assets/ab-insightful-embed.js
@@ -213,6 +213,17 @@ async function submitExperimentUser(userId, experimentId, variantName, appUrl) {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
+
+    const body = res.ok ? await res.json().catch(() => null) : null;
+    const limitReached =
+      body?.result?.limitReached === true;
+
+    if (limitReached) {
+      // Experiment at max users; assignment was not persisted. Keep showing
+      // the client-assigned variant for consistent UX. Do not retry.
+      return;
+    }
+
     if (!res.ok) throw new Error("Server responded with " + res.status);
   } catch (err) {
     console.error(

--- a/prisma/migrations/20260317223817_add_max_users_per_experiment/migration.sql
+++ b/prisma/migrations/20260317223817_add_max_users_per_experiment/migration.sql
@@ -1,0 +1,23 @@
+-- AlterTable
+ALTER TABLE "Experiment" ADD COLUMN "max_users" INTEGER;
+
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Project" (
+    "project_id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "shop" TEXT NOT NULL,
+    "name" TEXT,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "default_goal" TEXT NOT NULL DEFAULT 'completedCheckout',
+    "max_users_per_experiment" INTEGER NOT NULL DEFAULT 10000,
+    "emailNotifEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "enableExperimentStart" BOOLEAN NOT NULL DEFAULT false,
+    "enableExperimentEnd" BOOLEAN NOT NULL DEFAULT false
+);
+INSERT INTO "new_Project" ("created_at", "default_goal", "emailNotifEnabled", "enableExperimentEnd", "enableExperimentStart", "name", "project_id", "shop") SELECT "created_at", "default_goal", "emailNotifEnabled", "enableExperimentEnd", "enableExperimentStart", "name", "project_id", "shop" FROM "Project";
+DROP TABLE "Project";
+ALTER TABLE "new_Project" RENAME TO "Project";
+CREATE UNIQUE INDEX "Project_shop_key" ON "Project"("shop");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -39,7 +39,7 @@ model Project {
   name        String?
   created_at  DateTime @default(now()) @map("created_at")
   defaultGoal String   @default("completedCheckout") @map("default_goal")
-  
+  maxUsersPerExperiment Int @default(10000) @map("max_users_per_experiment")
 
   experiments Experiment[] // Virtual Field indicating "look @ the experiment model/table for any row that points back to me"
   audiences   Audience[] // List[] uses Foregin keys as links to models to know where to look
@@ -93,6 +93,7 @@ model Experiment {
   probabilityToBeBest Int?      @map("probability_to_be_best")
   duration            Int?
   timeUnit            TimeUnit? @map("time_unit")
+  maxUsers            Int?      @map("max_users")
 
   projectId Int     @map("project_id") // Foreign key
   project   Project @relation(fields: [projectId], references: [id], onDelete: Cascade) // connects to Project's PK

--- a/prisma/seed.base.js
+++ b/prisma/seed.base.js
@@ -11,10 +11,11 @@ export async function seedBase(prisma) {
   // ----- Project -----
   const project = await prisma.project.upsert({
     where: { shop: 'dev-example.myshopify.com' },
-    update: { name: 'Dev Example Project' },
+    update: { name: 'Dev Example Project', maxUsersPerExperiment: 10000 },
     create: {
       shop: 'dev-example.myshopify.com',
       name: 'Dev Example Project',
+      maxUsersPerExperiment: 10000,
     },
   });
 


### PR DESCRIPTION
Adds support for limiting the number of visitors per experiment. Users can set an account-wide default and optionally override it per experiment.

**Changes**
Database: Project -> maxUsersPerExperiment – account default max users(1–1,000,000, default 10,000)
Experiment -> maxUsers – optional per-experiment override; when null, uses project default

Settings: New “Max users per experiment” field in Settings to set account default. Must be an integer, 1–1,000,000

Create / Edit Experiment: “Use account default” checkbox (default on)
Optional custom max users when unchecked
Same validation rules as settings

Allocation: Embed script and collect API enforce the limit
New visitors are not allocated once the limit is reached
Uses experiment override when set, otherwise project default

Reporting: Max users shown in experiment list and report views

Testing: updateMaxUsersPerExperiment action (settings): validation and save
validateMaxUsers utility: experiment create/edit validation
createExperiment service: maxUsers storage
Integration tests: allocation respects experiment override vs project default