### PR TITLE
script for switching db implemented

### DIFF
--- a/app/__tests__/switch-db.test.js
+++ b/app/__tests__/switch-db.test.js
@@ -1,0 +1,49 @@
+import fs from "fs";
+import path from "path";
+import { execSync } from "child_process";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+
+const ENV_PATH = path.resolve(process.cwd(), ".env");
+const CONFIG_PATH = path.resolve(process.cwd(), "config/db.environment.config.json");
+
+const TEST_ENV_CONTENT = `FOO=bar\nDATABASE_URL="file:./old.sqlite"\n`;
+
+describe("switch-db script", () => {
+  beforeEach(() => {
+    // create fake .env
+    fs.writeFileSync(ENV_PATH, TEST_ENV_CONTENT, "utf8");
+
+    // create fake config
+    fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
+    fs.writeFileSync(
+      CONFIG_PATH,
+      JSON.stringify({
+        dev: "file:./dev.sqlite",
+        test: "file:./test.sqlite",
+      }),
+      "utf8"
+    );
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(ENV_PATH)) fs.unlinkSync(ENV_PATH);
+    if (fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
+  });
+
+  it("updates DATABASE_URL to dev", () => {
+    execSync(`node scripts/switch-db.js --environment=dev`);
+
+    const env = fs.readFileSync(ENV_PATH, "utf8");
+
+    expect(env).toContain(`DATABASE_URL="file:./dev.sqlite"`);
+    expect(env).toContain(`FOO=bar`); // ensures we didn’t wipe file
+  });
+
+  it("updates DATABASE_URL to test", () => {
+    execSync(`node scripts/switch-db.js --environment=test`);
+
+    const env = fs.readFileSync(ENV_PATH, "utf8");
+
+    expect(env).toContain(`DATABASE_URL="file:./test.sqlite"`);
+  });
+});

--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -49,7 +49,14 @@ export const loader = async ({ request }) => {
   //checks to see if web pixel already exists, used as conditional to web pixel section later
   const { webPixelNotNull} = await import ("../services/session.server");
   
-  const tutorialData = await getTutorialData();
+  //for the love of god handle the nulls
+  const tutorialData = (await getTutorialData()) ?? {
+    generalSettings: false,
+    createExperiment: false,
+    viewedListExperiment: false,
+    viewedReportsPage: false,
+    onSiteTracking: false,
+  };
   const webPixelRes = await webPixelNotNull();
 
   tutorialData.allSetupDone= (

--- a/db.environment.config.json
+++ b/db.environment.config.json
@@ -1,0 +1,5 @@
+{
+  "dev": "file:./dev.sqlite",
+  "test": "file:./test.sqlite",
+  "prod": "file:./prod.sqlite"
+}

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "react-router build",
-    "dev": "npm run seed:dev && shopify app dev",
+    "dev": "shopify app dev",
     "config:link": "shopify app config link",
     "generate": "shopify app generate",
     "deploy": "shopify app deploy",
@@ -18,12 +18,24 @@
     "graphql-codegen": "graphql-codegen",
     "vite": "vite",
     "typecheck": "react-router typegen && tsc --noEmit",
+
     "test": "vitest run --coverage",
     "test:watch": "vitest",
     "test:integration": "npm run seed:test && vitest run --config vitest.integration.config.js --coverage",
+
     "seed:dev": "node prisma/seed.js --environment=dev",
     "seed:test": "node prisma/seed.js --environment=test",
-    "seed:demo": "node prisma/seed.js --environment=demo"
+    "seed:demo": "node prisma/seed.js --environment=demo",
+
+    "db:dev": "node scripts/switch-db.js --environment=dev",
+    "db:test": "node scripts/switch-db.js --environment=test",
+    "db:prod": "node scripts/switch-db.js --environment=prod",
+    "db:switch": "node scripts/switch-db.js",
+    "db:migrate": "prisma migrate deploy",
+
+    "launch:dev": "npm run db:dev && shopify app dev",
+    "launch:test": "npm run db:test && shopify app dev",
+    "launch:prod": "npm run db:prod  && shopify app dev"
   },
   "prisma": {
     "seed:dev": "node prisma/seed.js --environment=dev",

--- a/scripts/switch-db.js
+++ b/scripts/switch-db.js
@@ -1,0 +1,65 @@
+
+import fs from "fs";
+import path from "path";
+
+const envFilePath = path.resolve(process.cwd(), ".env");
+const configPath = path.resolve(process.cwd(), "db.environment.config.json");
+
+//parse passed args
+function parseArgs() {
+  const envArg = process.argv.find((arg) => arg.startsWith("--environment="));
+  if (!envArg) {
+    console.error("Missing --environment argument. Use --environment=dev|test|prod");
+    process.exit(1);
+  }
+
+  return envArg.split("=")[1];
+}
+
+//check config file
+function loadConfig() {
+  if (!fs.existsSync(configPath)) {
+    console.error(`Missing config file: ${configPath}`);
+    process.exit(1);
+  }
+
+  return JSON.parse(fs.readFileSync(configPath, "utf8"));
+}
+
+//update .env file, only touches DATABASE_URL
+function updateEnvFile(databaseUrl) {
+  let envContent = "";
+
+  if (fs.existsSync(envFilePath)) {
+    envContent = fs.readFileSync(envFilePath, "utf8");
+  }
+
+  const dbLine = `DATABASE_URL="${databaseUrl}"`;
+
+  if (/^DATABASE_URL=.*$/m.test(envContent)) {
+    envContent = envContent.replace(/^DATABASE_URL=.*$/m, dbLine);
+  } else {
+    envContent = envContent.trim()
+      ? `${envContent.trim()}\n${dbLine}\n`
+      : `${dbLine}\n`;
+  }
+
+  fs.writeFileSync(envFilePath, envContent, "utf8");
+}
+
+function main() {
+  const environment = parseArgs();
+  const config = loadConfig();
+
+  if (!config[environment]) {
+    console.error(`Invalid environment: ${environment}`);
+    console.error(`Valid environments: ${Object.keys(config).join(", ")}`);
+    process.exit(1);
+  }
+
+  updateEnvFile(config[environment]);
+
+  console.log(`DATABASE_URL switched to ${environment}`);
+}
+
+main();


### PR DESCRIPTION
Implemented scripts to easily switch between different local databases (dev, test, prod) without having to manually edit local .env file.

**Command Changes Implemented**

- Switching to a different database
  - `npm run db:dev` : switches `DATABASE_URL` to `dev.sqlite`
  - `npm run db:test` : switches `DATABASE_URL` to `test.sqlite`
  - `npm run db:prod` : switches `DATABASE_URL` to `prod.sqlite`
  - `npm run db:switch -- --environment={INSERT HERE}` : switches `DATABASE_URL` to the {INSERT HERE} file
- Migration command
  - `npm run db:migrate` : applies existing migrations to currently selected db
- Switching db and launching Cloudflare tunnel
  - `npm run launch:dev` : Switches `DATABASE_URL` to `dev.sqlite` then runs `shopify app dev`
  - `npm run launch:test` : Switches `DATABASE_URL` to `test.sqlite` then runs `shopify app dev`
  - `npm run launch:prod` Switches `DATABASE_URL` to `prod.sqlite` then runs `shopify app dev`
- Changes to existing commands
  - `npm run dev` :  auto seed disabled before calling `shopify app dev`


**IMPORTANT TIDBITS**

1. On a fresh/new database (after deleting a `.sqlite` file or creating a new db) you must run migrations before seeding. : To apply migrations to db by either initiating `shopify app dev` or `npm run db:migrate` 
2. Seeding must be run separately, flow should go switch db -> apply migrations -> seed -> run the shopify CLI


Passes `switch-db.test.js` and all other existing tests remain unbroken

<img width="1500" height="1519" alt="image" src="https://github.com/user-attachments/assets/a2de97cd-7f0f-4d91-9f3c-98d0a40b9015" />
