### PR TITLE
ET-572: Implemented breadcrumbs

### DIFF
--- a/app/__tests__/breadcrumbs.test.jsx
+++ b/app/__tests__/breadcrumbs.test.jsx
@@ -1,0 +1,128 @@
+import { render, screen, cleanup } from "@testing-library/react";
+import { afterEach, describe, expect, test, vi } from "vitest";
+import * as reactRouter from "react-router";
+
+import EditExperiment from "../routes/app.experiments.$id";
+import CreateExperiment from "../routes/app.experiments.new";
+import Report from "../routes/app.reports.$id";
+
+// --------------------
+// shared mocks
+// --------------------
+vi.mock("react-router", async () => {
+  const actual = await vi.importActual("react-router");
+  return {
+    ...actual,
+    useLoaderData: vi.fn(),
+    useFetcher: vi.fn(() => ({
+      state: "idle",
+      data: null,
+      submit: vi.fn(),
+    })),
+    useRevalidator: vi.fn(() => ({
+      revalidate: vi.fn(),
+    })),
+    useSearchParams: vi.fn(() => [new URLSearchParams(), vi.fn()]),
+  };
+});
+
+vi.mock("../contexts/DateRangeContext", () => ({
+  useDateRange: () => ({
+    dateRange: {
+      start: "2026-03-01",
+      end: "2026-03-31",
+    },
+  }),
+  formatDateForDisplay: vi.fn(),
+}));
+
+vi.mock("../components/DateRangePicker", () => ({
+  default: () => <div>DateRangePicker</div>,
+}));
+
+vi.mock("recharts", () => ({
+  LineChart: ({ children }) => <div>{children}</div>,
+  Line: () => <div>Line</div>,
+  XAxis: () => <div>XAxis</div>,
+  YAxis: () => <div>YAxis</div>,
+  CartesianGrid: () => <div>CartesianGrid</div>,
+  Tooltip: () => <div>Tooltip</div>,
+  Legend: () => <div>Legend</div>,
+  ResponsiveContainer: ({ children }) => <div>{children}</div>,
+  ReferenceLine: () => <div>ReferenceLine</div>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+// helper: find an s-link by visible text and read href off the custom element
+function expectBreadcrumb(label, href) {
+  const crumb = screen.getByText(label);
+  expect(crumb).toBeInTheDocument();
+  expect(crumb.closest("s-link") ?? crumb).toHaveAttribute("href", href);
+}
+
+describe("breadcrumb links", () => {
+  test("create experiment breadcrumb goes back to experiments list", () => {
+    vi.spyOn(reactRouter, "useLoaderData").mockReturnValue({
+      defaultGoal: "completedCheckout",
+      tutorialData: { createExperiment: true },
+      shopDomain: "test-shop.myshopify.com",
+    });
+
+    render(<CreateExperiment />);
+
+    expectBreadcrumb("Experiments", "/app/experiments");
+  });
+
+  test("edit experiment breadcrumb goes back to that experiment's report page", () => {
+    vi.spyOn(reactRouter, "useLoaderData").mockReturnValue({
+      shop: "test-shop.myshopify.com",
+      appHandle: "ab-insightful",
+      experiment: {
+        id: 123,
+        status: "draft",
+        name: "Homepage Test",
+        description: "desc",
+        controlSectionId: "",
+        variants: [{ sectionId: "section-a", trafficAllocation: 50 }],
+        startDate: "",
+        startTime: "",
+        endDate: "",
+        endTime: "",
+        endCondition: "manual",
+        goal: "completedCheckout",
+        probabilityToBeBest: null,
+        duration: null,
+        timeUnit: null,
+      },
+    });
+
+    render(<EditExperiment />);
+
+    expectBreadcrumb("Report View", "/app/reports/123");
+  });
+
+  test("report page breadcrumb goes back to experiments list", () => {
+    vi.spyOn(reactRouter, "useLoaderData").mockReturnValue({
+      deviceSegment: "all",
+      analysis: [],
+      experiment: {
+        id: 456,
+        name: "Checkout Test",
+        status: "draft",
+        sectionId: "sec-1",
+        startDate: null,
+        experimentGoals: [],
+        analyses: [],
+        variants: [],
+      },
+    });
+
+    render(<Report />);
+
+    expectBreadcrumb("Experiments", "/app/experiments");
+  });
+});

--- a/app/routes/app.experiments.$id.jsx
+++ b/app/routes/app.experiments.$id.jsx
@@ -1056,6 +1056,7 @@ export default function EditExperiment() {
 
   return (
     <s-page heading="Edit Experiment" variant="headingLg">
+      <s-link slot="breadcrumb-actions" href={`/app/reports/${experiment.id}`}>Report View</s-link>
       {/* Success Notification UI Component */}
       { showSuccessBanner && (
         <s-box paddingBlockend="base">

--- a/app/routes/app.experiments.new.jsx
+++ b/app/routes/app.experiments.new.jsx
@@ -792,6 +792,7 @@ export default function CreateExperiment() {
 
   return (
     <s-page heading="Create Experiment" variant="headingLg">
+      <s-link slot="breadcrumb-actions" href="/app/experiments">Experiments</s-link>
       {/*modal popup for tutorial */}
       <s-modal
         id="tutorial-modal-create-exp"
@@ -830,9 +831,6 @@ export default function CreateExperiment() {
       </s-button>
       <s-button slot="secondary-actions" onClick={handleDiscard}>
         Discard
-      </s-button>
-      <s-button slot="secondary-actions" href="/app/experiments">
-        Back to Experiment List
       </s-button>
       {(errors.form || errors.goal) && (
         <s-box padding="base">

--- a/app/routes/app.reports.$id.jsx
+++ b/app/routes/app.reports.$id.jsx
@@ -426,6 +426,7 @@ export default function Report() {
   const heading = experiment?.name ? `Report - ${experiment.name}` : "Report";
   return (
     <s-page heading={heading}>
+      <s-link slot="breadcrumb-actions" href="/app/experiments">Experiments</s-link>
       {/* Action button */}
       <s-button 
         slot="primary-action" 


### PR DESCRIPTION
Implemented breadcrumb-style navigation across key experiment and reporting pages

##Breadcrumb actions added**

- **Create Experiment**
  - `Experiments → /app/experiments`

- **Edit Experiment**
  - `Report View → /app/reports/:id`

- **Report Page**
  - `Experiments → /app/experiments`

Breadcrumbs pass test `app/__tests__breadcrumbs.test.jsx`