### PR TITLE
Dont display chart when empty.

### DIFF
--- a/app/components/SessionsCard.jsx
+++ b/app/components/SessionsCard.jsx
@@ -37,7 +37,12 @@ export default function SessionsCard({ sessionData }) {
         }}>
           <div style={{ height: "250px", width: "100%" , minHeight: "250px", position: "relative"}}>
             {isClient ? (
-              <ResponsiveContainer width="100%" height="100%" minWidth="0px">
+                sessions.length === 0 ? (
+                  <div style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                    <s-text color="subdued">No session data to display yet.</s-text>
+                  </div>
+                ) : (
+                <ResponsiveContainer width="100%" height="100%" minWidth="0px">
                 <AreaChart data={sessions} debounce={50} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
                   <defs>
                     <linearGradient id="colorSessions" x1="0" y1="0" x2="0" y2="1">
@@ -87,6 +92,7 @@ export default function SessionsCard({ sessionData }) {
                   />
                 </AreaChart>
               </ResponsiveContainer>
+              )
             ) : (
               <div style={{ textAlign: "center", paddingTop: "100px" }}>
                 <s-text tone="subdued">Loading chart data...</s-text>

--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -531,37 +531,45 @@ export default function Index() {
         </div>
       <s-section heading="Probability To Be The Best">
               {isClient ? (
-                <ResponsiveContainer width="100%" height={400}>
-                  <LineChart data={filteredPData}>
-                    <CartesianGrid strokeDasharray="3 3" />
-                    <XAxis dataKey="name" />
-                    <YAxis
-                      width={80}
-                      tickFormatter={(value) => `${(value * 100).toFixed(0)}%`}
-                      label={{
-                        value: "Probability to be the best (%)",
-                        angle: -90,
-                        position: "insideLeft",
-                        style: { textAnchor: "middle" },
-                      }}
-                    />
-                    <Tooltip />
-                    <Legend />
-                    {experiment.variants.map((v, index) => {
-                      const colors = ["#5C6AC4", "#9C6ADE", "#00A0AC", "#FFC447"];
-                      return (
-                        <Line
-                          key={v.id}
-                          type="monotone"
-                          dataKey={v.name}
-                          stroke={colors[index % colors.length]}
-                          activeDot={{ r: 8 }}
-                          dot={false}
+                  filteredPData.length === 0 ? (
+                    <s-box padding="extraLarge" borderRadius="base" background="subdued">
+                      <s-stack direction="block" gap="small" alignItems="center">
+                        <s-text color="subdued">No data available for the selected date range.</s-text>
+                      </s-stack>
+                    </s-box>
+                  ) : (
+                    <ResponsiveContainer width="100%" height={400}>
+                      <LineChart data={filteredPData}>
+                        <CartesianGrid strokeDasharray="3 3" />
+                        <XAxis dataKey="name" />
+                        <YAxis
+                          width={80}
+                          tickFormatter={(value) => `${(value * 100).toFixed(0)}%`}
+                          label={{
+                            value: "Probability to be the best (%)",
+                            angle: -90,
+                            position: "insideLeft",
+                            style: { textAnchor: "middle" },
+                          }}
                         />
-                      );
-                    })}
-                  </LineChart>
-                </ResponsiveContainer>
+                        <Tooltip />
+                        <Legend />
+                        {experiment.variants.map((v, index) => {
+                          const colors = ["#5C6AC4", "#9C6ADE", "#00A0AC", "#FFC447"];
+                          return (
+                            <Line
+                              key={v.id}
+                              type="monotone"
+                              dataKey={v.name}
+                              stroke={colors[index % colors.length]}
+                              activeDot={{ r: 8 }}
+                              dot={false}
+                            />
+                          );
+                        })}
+                      </LineChart>
+                    </ResponsiveContainer>
+                  )
               ) : (
                 <div style={{ width: 700, height: 400 }}>Loading chart...</div>
               )}

--- a/app/routes/app.reports.$id.jsx
+++ b/app/routes/app.reports.$id.jsx
@@ -625,104 +625,128 @@ export default function Report() {
       <s-section> {/* Variant Success Rate [might be broken - Paul]*/}
       <s-heading>Variant Success Rate</s-heading>
         {/* Table Section of experiment list page */}
-        <s-box  background="base"
-                border="base"
-                borderRadius="base"
-                overflow="hidden"> {/*box used to provide a curved edge table */}
-          <s-table>
-            <s-table-header-row>
-              <s-table-header listslot='primary'>Variant Name</s-table-header>
-              <s-table-header listSlot="secondary">Goal Completion Rate</s-table-header>
-              <s-table-header listSlot="labeled">Improvement %</s-table-header>
-              <s-table-header listSlot="labeled" format="numeric">Probability to be Best</s-table-header>
-              <s-table-header listSlot="labeled" format="numeric">Expected Loss</s-table-header>
-              <s-table-header listSlot="labeled" >Goal Completion / Visitor</s-table-header>
-            </s-table-header-row>
-              <s-table-body>
-                {renderTableData()}
-              </s-table-body>
-            </s-table>
-        </s-box> {/*end of table section*/}
+          {safeAnalysis.length === 0 ? (
+            <s-box padding="extraLarge" borderRadius="base" background="subdued">
+              <s-stack direction="block" gap="small" alignItems="center">
+                <s-text color="subdued">No analysis data yet. Start the experiment to begin collecting results.</s-text>
+              </s-stack>
+            </s-box>
+          ) : (
+            <s-box  background="base"
+                    border="base"
+                    borderRadius="base"
+                    overflow="hidden">
+              <s-table>
+                <s-table-header-row>
+                  <s-table-header listslot='primary'>Variant Name</s-table-header>
+                  <s-table-header listSlot="secondary">Goal Completion Rate</s-table-header>
+                  <s-table-header listSlot="labeled">Improvement %</s-table-header>
+                  <s-table-header listSlot="labeled" format="numeric">Probability to be Best</s-table-header>
+                  <s-table-header listSlot="labeled" format="numeric">Expected Loss</s-table-header>
+                  <s-table-header listSlot="labeled" >Goal Completion / Visitor</s-table-header>
+                </s-table-header-row>
+                <s-table-body>
+                  {renderTableData()}
+                </s-table-body>
+              </s-table>
+            </s-box>
+          )}
       </s-section>
       <s-section heading="Probability To Be The Best">
         {isClient ? (
-          <ResponsiveContainer width="100%" height={400}>
-            <LineChart data={filteredPData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis
-                width={80}
-                tickFormatter={(value) => `${(value * 100).toFixed(0)}%`}
-                label={{
-                  value: "Probability to be the best (%)",
-                  angle: -90,
-                  position: "insideLeft",
-                  style: { textAnchor: "middle" },
-                }}
-              />
-              <Tooltip formatter={(value) => `${(value * 100).toFixed(2)}%`} />
-              <Legend />
-              <ReferenceLine
-              y={0.8}
-              stroke="#2c2d2c"
-              strokeDasharray="5.5"
-              />
-              {/* Dynamically renders all variants */}
-              { experiment.variants.map((v, index) => {
-                // Array of colors to distinguis variants
-                const colors = ["#5C6AC4", "#9C6ADE", "#00A0AC", "#FFC447"];
-                return(
-                  <Line
-                  key={v.id}
-                  type="monotone"
-                  dataKey={v.name}
-                  stroke={colors[index % colors.length]}
-                  activeDot={{ r: 8 }}
-                  dot={false}
+            filteredPData.length === 0 ? (
+              <s-box padding="extraLarge" borderRadius="base" background="subdued">
+                <s-stack direction="block" gap="small" alignItems="center">
+                  <s-text color="subdued">No data available for the selected date range.</s-text>
+                </s-stack>
+              </s-box>
+            ) : (
+            <ResponsiveContainer width="100%" height={400}>
+              <LineChart data={filteredPData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis
+                  width={80}
+                  tickFormatter={(value) => `${(value * 100).toFixed(0)}%`}
+                  label={{
+                    value: "Probability to be the best (%)",
+                    angle: -90,
+                    position: "insideLeft",
+                    style: { textAnchor: "middle" },
+                  }}
                 />
-              );
-              })}
-            </LineChart>
-          </ResponsiveContainer>
+                <Tooltip formatter={(value) => `${(value * 100).toFixed(2)}%`} />
+                <Legend />
+                <ReferenceLine
+                y={0.8}
+                stroke="#2c2d2c"
+                strokeDasharray="5.5"
+                />
+                {/* Dynamically renders all variants */}
+                { experiment.variants.map((v, index) => {
+                  // Array of colors to distinguis variants
+                  const colors = ["#5C6AC4", "#9C6ADE", "#00A0AC", "#FFC447"];
+                  return(
+                    <Line
+                    key={v.id}
+                    type="monotone"
+                    dataKey={v.name}
+                    stroke={colors[index % colors.length]}
+                    activeDot={{ r: 8 }}
+                    dot={false}
+                  />
+                );
+                })}
+              </LineChart>
+            </ResponsiveContainer>
+            )
         ) : (
           <div style={{ width: 700, height: 400 }}>Loading chart...</div>
         )}
       </s-section>
       <s-section heading="Expected Loss">
         {isClient ? (
-          <ResponsiveContainer width="100%" height={400}>
-            <LineChart data={filteredELData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="name" />
-              <YAxis
-                width={80}
-                tickFormatter={(value) => `${(value * 100).toFixed(0)}%`}
-                label={{
-                  value: "Expected Loss (%)",
-                  angle: -90,
-                  position: "insideLeft",
-                  style: { textAnchor: "middle" },
-                }}
-              />
-              <Tooltip formatter={(value) => `${(value * 100).toFixed(2)}%`} />
-              <Legend />
-              {/* Dynamically renders all variants */}
-              { experiment.variants.map((v, index) => {
-                // Array of colors to distinguis variants
-                const colors = ["#5C6AC4", "#9C6ADE", "#00A0AC", "#FFC447"];
-                return(
-                  <Line
-                  key={v.id}
-                  type="monotone"
-                  dataKey={v.name}
-                  stroke={colors[index % colors.length]}
-                  activeDot={{ r: 8 }}
-                  dot={false}
+            filteredELData.length === 0 ? (
+              <s-box padding="extraLarge" borderRadius="base" background="subdued">
+                <s-stack direction="block" gap="small" alignItems="center">
+                  <s-text color="subdued">No data available for the selected date range.</s-text>
+                </s-stack>
+              </s-box>
+            ) : (
+            <ResponsiveContainer width="100%" height={400}>
+              <LineChart data={filteredELData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="name" />
+                <YAxis
+                  width={80}
+                  tickFormatter={(value) => `${(value * 100).toFixed(0)}%`}
+                  label={{
+                    value: "Expected Loss (%)",
+                    angle: -90,
+                    position: "insideLeft",
+                    style: { textAnchor: "middle" },
+                  }}
                 />
-              );
-              })}
-            </LineChart>
-          </ResponsiveContainer>
+                <Tooltip formatter={(value) => `${(value * 100).toFixed(2)}%`} />
+                <Legend />
+                {/* Dynamically renders all variants */}
+                { experiment.variants.map((v, index) => {
+                  // Array of colors to distinguis variants
+                  const colors = ["#5C6AC4", "#9C6ADE", "#00A0AC", "#FFC447"];
+                  return(
+                    <Line
+                    key={v.id}
+                    type="monotone"
+                    dataKey={v.name}
+                    stroke={colors[index % colors.length]}
+                    activeDot={{ r: 8 }}
+                    dot={false}
+                  />
+                );
+                })}
+              </LineChart>
+            </ResponsiveContainer>
+            )
         ) : (
           <div style={{ width: 700, height: 400 }}>Loading chart...</div>
         )}


### PR DESCRIPTION
For any given graphical data presented to the user for the experiment report they should be presented with an alternate visual when there is no data points for the graph or no graph at all. 

Acceptance:

should display visual when no data

should display data when available