### PR TITLE
Et 574 amazon sns text msg reporting

### DIFF
--- a/app/__tests__/api.cron.poll-experiments.test.jsx
+++ b/app/__tests__/api.cron.poll-experiments.test.jsx
@@ -57,6 +57,8 @@ describe("routes/api.cron.poll-experiments.jsx loader", () => {
     vi.doMock("../services/notifications.server", () => ({
         sendEmailStart: vi.fn(),
         sendEmailEnd: vi.fn(),
+        sendSMSStart: vi.fn(),
+        sendSMSEnd: vi.fn()
     }));
 
     const mod = await import("../routes/api.cron.poll-experiments.jsx");
@@ -240,4 +242,168 @@ describe("routes/api.cron.poll-experiments.jsx loader", () => {
     expect(response.status).toBe(405);
     expect(await response.text()).toBe("");
   });
+
+  //covers new SMS branch (happy branch) 
+  test("GET: sends SMS start notification when experiment start + sms notifications are enabled", async () => {
+    vi.resetModules();
+
+    const getCandidatesForScheduledEnd = vi.fn().mockResolvedValue([]);
+    const getCandidatesForScheduledStart = vi.fn().mockResolvedValue([
+      { id: 101, name: "Exp A", projectId: 55 },
+    ]);
+    const endExperiment = vi.fn();
+    const startExperiment = vi.fn().mockResolvedValue(undefined);
+
+    const sendEmailStart = vi.fn();
+    const sendSMSStart = vi.fn();
+    const sendEmailEnd = vi.fn();
+    const sendSMSEnd = vi.fn();
+
+    mockProjectFindUnique.mockResolvedValue({
+      enableExperimentStart: true,
+      emailNotifEnabled: false,
+      smsNotifEnabled: true,
+      shop: "test.myshopify.com",
+    });
+
+    vi.doMock("../services/experiment.server", () => ({
+      getCandidatesForScheduledEnd,
+      getCandidatesForScheduledStart,
+      endExperiment,
+      startExperiment,
+    }));
+
+    vi.doMock("../db.server", () => ({
+      default: {
+        project: { findUnique: mockProjectFindUnique },
+      },
+    }));
+
+    vi.doMock("../services/notifications.server", () => ({
+      sendEmailStart,
+      sendSMSStart,
+      sendEmailEnd,
+      sendSMSEnd,
+    }));
+
+    const { loader } = await import("../routes/api.cron.poll-experiments.jsx");
+
+    const response = await loader({
+      request: makeRequest("GET", { "Cron-Secret": "test-secret" }),
+    });
+
+    expect(response.status).toBe(200);
+    expect(startExperiment).toHaveBeenCalledWith(101);
+    expect(sendSMSStart).toHaveBeenCalledTimes(1);
+    expect(sendSMSStart).toHaveBeenCalledWith(101, "Exp A", "test.myshopify.com");
+    expect(sendEmailStart).not.toHaveBeenCalled();
+
+  });
+
+  test("GET: records failure when sendSMSStart throws", async () => {
+    vi.resetModules();
+
+    const getCandidatesForScheduledEnd = vi.fn().mockResolvedValue([]);
+    const getCandidatesForScheduledStart = vi.fn().mockResolvedValue([
+      { id: 101, name: "Exp A", projectId: 55 },
+    ]);
+    const endExperiment = vi.fn();
+    const startExperiment = vi.fn().mockResolvedValue(undefined);
+
+    const sendEmailStart = vi.fn();
+    const sendSMSStart = vi.fn().mockRejectedValue(new Error("sms failed"));
+    const sendEmailEnd = vi.fn();
+    const sendSMSEnd = vi.fn();
+
+    mockProjectFindUnique.mockResolvedValue({
+      enableExperimentStart: true,
+      emailNotifEnabled: false,
+      smsNotifEnabled: true,
+      shop: "test.myshopify.com",
+    });
+
+    vi.doMock("../services/experiment.server", () => ({
+      getCandidatesForScheduledEnd,
+      getCandidatesForScheduledStart,
+      endExperiment,
+      startExperiment,
+    }));
+
+    vi.doMock("../db.server", () => ({
+      default: {
+        project: { findUnique: mockProjectFindUnique },
+      },
+    }));
+
+    vi.doMock("../services/notifications.server", () => ({
+      sendEmailStart,
+      sendSMSStart,
+      sendEmailEnd,
+      sendSMSEnd,
+    }));
+
+    const { loader } = await import("../routes/api.cron.poll-experiments.jsx");
+
+    const response = await loader({
+      request: makeRequest("GET", { "Cron-Secret": "test-secret" }),
+    });
+
+    const body = await readJson(response);
+
+    expect(body.failures).toContain("sms failed");
+  });
+
+  test("GET: records failure when sendSMSStart throws", async () => {
+    vi.resetModules();
+
+    const getCandidatesForScheduledEnd = vi.fn().mockResolvedValue([]);
+    const getCandidatesForScheduledStart = vi.fn().mockResolvedValue([
+      { id: 101, name: "Exp A", projectId: 55 },
+    ]);
+    const endExperiment = vi.fn();
+    const startExperiment = vi.fn().mockResolvedValue(undefined);
+
+    const sendEmailStart = vi.fn();
+    const sendSMSStart = vi.fn().mockRejectedValue(new Error("sms failed"));
+    const sendEmailEnd = vi.fn();
+    const sendSMSEnd = vi.fn();
+
+    mockProjectFindUnique.mockResolvedValue({
+      enableExperimentStart: true,
+      emailNotifEnabled: false,
+      smsNotifEnabled: true,
+      shop: "test.myshopify.com",
+    });
+
+    vi.doMock("../services/experiment.server", () => ({
+      getCandidatesForScheduledEnd,
+      getCandidatesForScheduledStart,
+      endExperiment,
+      startExperiment,
+    }));
+
+    vi.doMock("../db.server", () => ({
+      default: {
+        project: { findUnique: mockProjectFindUnique },
+      },
+    }));
+
+    vi.doMock("../services/notifications.server", () => ({
+      sendEmailStart,
+      sendSMSStart,
+      sendEmailEnd,
+      sendSMSEnd,
+    }));
+
+    const { loader } = await import("../routes/api.cron.poll-experiments.jsx");
+
+    const response = await loader({
+      request: makeRequest("GET", { "Cron-Secret": "test-secret" }),
+    });
+
+    const body = await readJson(response);
+
+    expect(body.failures).toContain("sms failed");
+  });
+
 });

--- a/app/__tests__/notificationSettingsCluster.test.js
+++ b/app/__tests__/notificationSettingsCluster.test.js
@@ -332,8 +332,9 @@ beforeEach(() => {
   sendEmailEnd.mockReset();
 });
 
-it('set_email_notif_false runs toggle update (side effect)', async () => {
+it('set_email_notif_false disables email notifications and returns success', async () => {
   setEmailNotifToggle.mockResolvedValue({ id: 1, emailNotifEnabled: false });
+  db.project.update.mockResolvedValue({ id: 1, emailNotifEnabled: false });
 
   const request = makeRequest({ intent: 'set_email_notif_false' });
   const result = await action({ request });
@@ -341,15 +342,23 @@ it('set_email_notif_false runs toggle update (side effect)', async () => {
   expect(setEmailNotifToggle).toHaveBeenCalledTimes(1);
   expect(setEmailNotifToggle).toHaveBeenCalledWith(false);
 
+  expect(db.project.update).toHaveBeenCalledTimes(1);
+  expect(db.project.update).toHaveBeenCalledWith({
+    where: { shop: 'test-shop.myshopify.com' },
+    data: { emailNotifEnabled: false },
+  });
+
   expect(sendEmailStart).not.toHaveBeenCalled();
 
-  //document current behavior (falls through)
-  expect(result).toEqual({ error: "Unknown intent.", field: null });
+  expect(result).toEqual({
+    ok: true,
+    intent: 'set_email_notif_false',
+  });
 });
 
-it('set_email_notif_true runs toggle update AND sends email (side effects)', async () => {
+it('set_email_notif_true enables email notifications and returns success', async () => {
   setEmailNotifToggle.mockResolvedValue({ id: 1, emailNotifEnabled: true });
-  sendEmailStart.mockResolvedValue({ MessageId: 'abc-123' });
+  db.project.update.mockResolvedValue({ id: 1, emailNotifEnabled: true });
 
   const request = makeRequest({ intent: 'set_email_notif_true' });
   const result = await action({ request });
@@ -357,10 +366,18 @@ it('set_email_notif_true runs toggle update AND sends email (side effects)', asy
   expect(setEmailNotifToggle).toHaveBeenCalledTimes(1);
   expect(setEmailNotifToggle).toHaveBeenCalledWith(true);
 
-  expect(sendEmailStart).toHaveBeenCalledTimes(1);
+  expect(db.project.update).toHaveBeenCalledTimes(1);
+  expect(db.project.update).toHaveBeenCalledWith({
+    where: { shop: 'test-shop.myshopify.com' },
+    data: { emailNotifEnabled: true },
+  });
 
-  // document current behavior (falls through)
-  expect(result).toEqual({ error: "Unknown intent.", field: null });
+  expect(sendEmailStart).not.toHaveBeenCalled();
+
+  expect(result).toEqual({
+    ok: true,
+    intent: 'set_email_notif_true',
+  });
 });
 
 it('set_email_notif_true returns ok:false when setEmailNotifToggle throws and does not send email', async () => {
@@ -376,17 +393,5 @@ it('set_email_notif_true returns ok:false when setEmailNotifToggle throws and do
   errSpy.mockRestore();
 });
 
-it('set_email_notif_true returns ok:false when sendEmailStart throws', async () => {
-  setEmailNotifToggle.mockResolvedValue({ id: 1, emailNotifEnabled: true });
-  sendEmailStart.mockRejectedValue(new Error('SNS fail'));
-  const errSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
-  const request = makeRequest({ intent: 'set_email_notif_true' });
-  const result = await action({ request });
-
-  expect(setEmailNotifToggle).toHaveBeenCalledWith(true);
-  expect(result).toEqual({ ok: false, error: "failed to send email" });
-
-  errSpy.mockRestore();
-});
 

--- a/app/__tests__/notificationSettingsCluster.test.js
+++ b/app/__tests__/notificationSettingsCluster.test.js
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { setEmailNotifToggle } from '../services/project.server.js';
-import { sendEmailStart } from '../services/notifications.server.js';
+import { sendEmailStart, sendEmailEnd, sendSMSStart, sendSMSEnd } from '../services/notifications.server.js';
 
 //mock authenticate before importing action
 vi.mock('../shopify.server', () => ({
@@ -305,26 +305,22 @@ describe('app.settings action', () => {
 // email notification toggle
 // ------------------------------------------------------------------
 //shotgun approach since some of these mocks aren't working
-vi.mock('../services/project.server', () => ({
-  setEmailNotifToggle: vi.fn(),
-  getEmailNotifToggle: vi.fn(),
-}));
+
 vi.mock('../services/project.server.js', () => ({
   setEmailNotifToggle: vi.fn(),
   getEmailNotifToggle: vi.fn(),
 }));
 
-vi.mock('../services/notifications.server', () => ({
-    sendEmailStart: vi.fn(),
-    sendEmailEnd: vi.fn(),
-}));
-vi.mock('../services/notifications.server.js', () => ({
-  sendEmailTopic: vi.fn(),
+
+vi.mock("../services/notifications.server.js", () => ({
   subscribeEmail: vi.fn(),
   unsubscribeEmail: vi.fn(),
+  subscribePhoneNum: vi.fn(),
+  unsubscribePhoneNum: vi.fn(),
   unsubscribeAll: vi.fn(),
-    sendEmailStart: vi.fn(),
-    sendEmailEnd: vi.fn(),
+  unsubscribeAllPhoneNums: vi.fn(),
+  sendEmailStart: vi.fn(),
+  sendEmailEnd: vi.fn(),
 }));
 
 //fixes mock issues
@@ -332,6 +328,8 @@ beforeEach(() => {
   vi.clearAllMocks();
   setEmailNotifToggle.mockReset();
   sendEmailStart.mockReset();
+  sendEmailStart.mockReset();
+  sendEmailEnd.mockReset();
 });
 
 it('set_email_notif_false runs toggle update (side effect)', async () => {

--- a/app/__tests__/notifications.test.js
+++ b/app/__tests__/notifications.test.js
@@ -1,6 +1,20 @@
 // notifications.test.js
 import { describe, it, expect, beforeEach, vi } from "vitest";
 
+import {
+  determineWinner,
+  sendEmailEnd,
+  sendEmailStart,
+  subscribeEmail,
+  unsubscribeEmail,
+  unsubscribeAll,
+  subscribePhoneNum,
+  unsubscribePhoneNum,
+  sendSMSEnd,
+  sendSMSStart,
+  unsubscribeAllPhoneNums,
+} from "../services/notifications.server.js";
+
 // ─── Mock AWS SNS ─────────────────────────────────────────────────────────────
 // SNSClient must be mocked as a class — arrow functions can't be used with `new`
 const mockSend = vi.fn().mockResolvedValue({ MessageId: "mock-message-id-123" });
@@ -13,9 +27,39 @@ vi.mock("@aws-sdk/client-sns", () => {
         constructor(input) { this.input = input; this.__type = "PublishCommand"; }
     }
     class SubscribeCommand {
-        constructor(input) { this.input = input; this.__type = "SubscribeCommand"; }
+    constructor(input) {
+        this.input = input;
+        this.__type = "SubscribeCommand";
+        }
     }
-    return { SNSClient, PublishCommand, SubscribeCommand };
+
+    class ListSubscriptionsByTopicCommand {
+        constructor(input) {
+        this.input = input;
+        this.__type = "ListSubscriptionsByTopicCommand";
+        }
+    }
+
+    class UnsubscribeCommand {
+        constructor(input) {
+        this.input = input;
+        this.__type = "UnsubscribeCommand";
+        }
+    }
+    return {
+        SNSClient,
+        PublishCommand,
+        SubscribeCommand,
+        ListSubscriptionsByTopicCommand,
+        UnsubscribeCommand,
+    };
+    
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSend.mockReset();
+  mockSend.mockResolvedValue({ MessageId: "mock-message-id-123" });
 });
 
 // ─── Mock DB ──────────────────────────────────────────────────────────────────
@@ -41,11 +85,6 @@ vi.mock("../services/experiment.server.js", () => ({
 vi.mock("../services/variant.server.js", () => ({
     getVariants: mockGetVariants,
 }));
-
-// ─── Import after mocks are set up ───────────────────────────────────────────
-const { determineWinner, sendEmailEnd, sendEmailStart } = await import(
-    "../services/notifications.server.js"
-);
 
 // ─── Shared mock analysis data ────────────────────────────────────────────────
 
@@ -370,4 +409,373 @@ describe("notifications.server", () => {
             expect(mockSend).toHaveBeenCalledTimes(2);
         });
     });
+    
+    describe("subscribeEmail", () => {
+        it("calls SNS SubscribeCommand with email topic and email protocol", async () => {
+            mockSend.mockResolvedValueOnce({ SubscriptionArn: "arn:email-sub" });
+
+            const response = await subscribeEmail("user@example.com");
+            
+            expect(mockSend).toHaveBeenCalledOnce();
+            const sentCommand = mockSend.mock.calls[0][0];
+            
+            expect(sentCommand.__type).toBe("SubscribeCommand");
+            expect(sentCommand.input).toEqual({
+            TopicArn: process.env.AWS_TOPIC,
+            Protocol: "email",
+            Endpoint: "user@example.com",
+            });
+            expect(response).toEqual({ SubscriptionArn: "arn:email-sub" });
+        });
+    });
+
+    //testing for unsubscribeEmail
+    describe("unsubscribeEmail", () => {
+        it("unsubscribes matching email when found", async () => {
+            mockSend
+            .mockResolvedValueOnce({
+                Subscriptions: [
+                { Endpoint: "other@example.com", SubscriptionArn: "arn:other" },
+                { Endpoint: "user@example.com", SubscriptionArn: "arn:target" },
+                ],
+                NextToken: undefined,
+            })
+            .mockResolvedValueOnce({
+                $metadata: { httpStatusCode: 200 },
+            });
+
+            await unsubscribeEmail("user@example.com");
+
+            expect(mockSend).toHaveBeenCalledTimes(2);
+
+            expect(mockSend.mock.calls[0][0].__type).toBe("ListSubscriptionsByTopicCommand");
+            expect(mockSend.mock.calls[1][0].__type).toBe("UnsubscribeCommand");
+            expect(mockSend.mock.calls[1][0].input).toEqual({
+            SubscriptionArn: "arn:target",
+            });
+        });
+
+        it("returns early when matching email is PendingConfirmation", async () => {
+            mockSend.mockResolvedValueOnce({
+            Subscriptions: [
+                { Endpoint: "user@example.com", SubscriptionArn: "PendingConfirmation" },
+            ],
+            NextToken: undefined,
+            });
+
+            await unsubscribeEmail("user@example.com");
+
+            expect(mockSend).toHaveBeenCalledTimes(1);
+            expect(mockSend.mock.calls[0][0].__type).toBe("ListSubscriptionsByTopicCommand");
+        });
+
+        it("returns early when email is not found", async () => {
+            mockSend.mockResolvedValueOnce({
+            Subscriptions: [
+                { Endpoint: "other@example.com", SubscriptionArn: "arn:other" },
+            ],
+            NextToken: undefined,
+            });
+
+            await unsubscribeEmail("user@example.com");
+
+            expect(mockSend).toHaveBeenCalledTimes(1);
+            expect(mockSend.mock.calls[0][0].__type).toBe("ListSubscriptionsByTopicCommand");
+        });
+
+        it("searches multiple pages until it finds the email", async () => {
+            mockSend
+            .mockResolvedValueOnce({
+                Subscriptions: [{ Endpoint: "other@example.com", SubscriptionArn: "arn:other" }],
+                NextToken: "page-2",
+            })
+            .mockResolvedValueOnce({
+                Subscriptions: [{ Endpoint: "user@example.com", SubscriptionArn: "arn:target" }],
+                NextToken: undefined,
+            })
+            .mockResolvedValueOnce({
+                $metadata: { httpStatusCode: 200 },
+            });
+
+            await unsubscribeEmail("user@example.com");
+
+            expect(mockSend).toHaveBeenCalledTimes(3);
+            expect(mockSend.mock.calls[1][0].__type).toBe("ListSubscriptionsByTopicCommand");
+            expect(mockSend.mock.calls[1][0].input.NextToken).toBe("page-2");
+            expect(mockSend.mock.calls[2][0].__type).toBe("UnsubscribeCommand");
+        });
+    });
+
+    //unsubscribe all tests
+    describe("unsubscribeAll", () => {
+        it("removes all confirmed email subscriptions across pages", async () => {
+            mockSend
+            .mockResolvedValueOnce({
+                Subscriptions: [
+                { Endpoint: "a@example.com", SubscriptionArn: "arn:a" },
+                { Endpoint: "b@example.com", SubscriptionArn: "PendingConfirmation" },
+                ],
+                NextToken: "page-2",
+            })
+            .mockResolvedValueOnce({
+                Subscriptions: [
+                { Endpoint: "c@example.com", SubscriptionArn: "arn:c" },
+                ],
+                NextToken: undefined,
+            })
+            .mockResolvedValueOnce({})
+            .mockResolvedValueOnce({});
+
+            const result = await unsubscribeAll();
+
+            expect(result).toEqual({ ok: true, removed: 2 });
+            expect(mockSend).toHaveBeenCalledTimes(4);
+            expect(mockSend.mock.calls[2][0].__type).toBe("UnsubscribeCommand");
+            expect(mockSend.mock.calls[2][0].input.SubscriptionArn).toBe("arn:a");
+            expect(mockSend.mock.calls[3][0].input.SubscriptionArn).toBe("arn:c");
+        });
+
+        it("returns zero removed when there are no subscriptions", async () => {
+            mockSend.mockResolvedValueOnce({
+            Subscriptions: [],
+            NextToken: undefined,
+            });
+
+            const result = await unsubscribeAll();
+
+            expect(result).toEqual({ ok: true, removed: 0 });
+            expect(mockSend).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    //subscribe phone number testing
+    describe("subscribePhoneNum", () => {
+        it("throws for invalid phone number length", async () => {
+            await expect(subscribePhoneNum("12345")).rejects.toThrow("invalid phone number format");
+        });
+
+        it("formats 10-digit phone number to E.164 and subscribes with sms protocol", async () => {
+            mockSend.mockResolvedValueOnce({ SubscriptionArn: "arn:sms-sub" });
+
+            const response = await subscribePhoneNum("9165551234");
+
+            expect(mockSend).toHaveBeenCalledOnce();
+            const sentCommand = mockSend.mock.calls[0][0];
+
+            expect(sentCommand.__type).toBe("SubscribeCommand");
+            expect(sentCommand.input).toEqual({
+            TopicArn: process.env.AWS_TOPIC_SMS,
+            Protocol: "sms",
+            Endpoint: "+19165551234",
+            });
+            expect(response).toEqual({ SubscriptionArn: "arn:sms-sub" });
+        });
+    });
+
+    describe("subscribePhoneNum", () => {
+        it("throws for invalid phone number length", async () => {
+            await expect(subscribePhoneNum("12345")).rejects.toThrow("invalid phone number format");
+        });
+
+        it("formats 10-digit phone number to E.164 and subscribes with sms protocol", async () => {
+            mockSend.mockResolvedValueOnce({ SubscriptionArn: "arn:sms-sub" });
+
+            const response = await subscribePhoneNum("9165551234");
+
+            expect(mockSend).toHaveBeenCalledOnce();
+            const sentCommand = mockSend.mock.calls[0][0];
+
+            expect(sentCommand.__type).toBe("SubscribeCommand");
+            expect(sentCommand.input).toEqual({
+            TopicArn: process.env.AWS_TOPIC_SMS,
+            Protocol: "sms",
+            Endpoint: "+19165551234",
+            });
+            expect(response).toEqual({ SubscriptionArn: "arn:sms-sub" });
+        });
+    });
+
+    describe("unsubscribePhoneNum", () => {
+        it("throws for invalid phone number length", async () => {
+            await expect(unsubscribePhoneNum("12345")).rejects.toThrow("invalid phone number format");
+        });
+
+        it("unsubscribes matching phone number when found", async () => {
+            mockSend
+            .mockResolvedValueOnce({
+                Subscriptions: [
+                { Endpoint: "+15551234567", SubscriptionArn: "arn:other" },
+                { Endpoint: "+19165551234", SubscriptionArn: "arn:target" },
+                ],
+                NextToken: undefined,
+            })
+            .mockResolvedValueOnce({
+                $metadata: { requestId: "req-1", httpStatusCode: 200 },
+            });
+
+            await unsubscribePhoneNum("9165551234");
+
+            expect(mockSend).toHaveBeenCalledTimes(2);
+            expect(mockSend.mock.calls[0][0].__type).toBe("ListSubscriptionsByTopicCommand");
+            expect(mockSend.mock.calls[1][0].__type).toBe("UnsubscribeCommand");
+            expect(mockSend.mock.calls[1][0].input).toEqual({
+            SubscriptionArn: "arn:target",
+            });
+        });
+
+        it("returns early when matching phone number is PendingConfirmation", async () => {
+            mockSend.mockResolvedValueOnce({
+            Subscriptions: [
+                { Endpoint: "+19165551234", SubscriptionArn: "PendingConfirmation" },
+            ],
+            NextToken: undefined,
+            });
+
+            await unsubscribePhoneNum("9165551234");
+
+            expect(mockSend).toHaveBeenCalledTimes(1);
+        });
+
+        it("returns early when phone number is not found", async () => {
+            mockSend.mockResolvedValueOnce({
+            Subscriptions: [
+                { Endpoint: "+15551234567", SubscriptionArn: "arn:other" },
+            ],
+            NextToken: undefined,
+            });
+
+            await unsubscribePhoneNum("9165551234");
+
+            expect(mockSend).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe("sendSMSStart", () => {
+        it("throws if experimentId is missing", async () => {
+            await expect(sendSMSStart(null, "My Experiment", "test.myshopify.com"))
+            .rejects.toThrow("experimentId is required");
+        });
+
+        it("throws if experimentName is missing", async () => {
+            await expect(sendSMSStart(1, null, "test.myshopify.com"))
+            .rejects.toThrow("experimentName is required");
+        });
+
+        it("throws if shop is missing", async () => {
+            await expect(sendSMSStart(1, "My Experiment", null))
+            .rejects.toThrow("shop is required");
+        });
+
+        it("publishes SMS start message to AWS_TOPIC_SMS without Subject", async () => {
+            const response = await sendSMSStart(1, "My Experiment", "test.myshopify.com");
+
+            expect(mockSend).toHaveBeenCalledOnce();
+            const sentCommand = mockSend.mock.calls[0][0];
+
+            expect(sentCommand.__type).toBe("PublishCommand");
+            expect(sentCommand.input.TopicArn).toBe(process.env.AWS_TOPIC_SMS);
+            expect(sentCommand.input.Message).toContain("My Experiment");
+            expect(sentCommand.input.Subject).toBeUndefined();
+            expect(response).toEqual({ MessageId: "mock-message-id-123" });
+        });
+    });
+
+    //sendSMSEnd function tests
+    describe("sendSMSEnd", () => {
+        beforeEach(() => {
+            mockGetVariants.mockResolvedValue([
+            { id: 1, name: "Control" },
+            { id: 2, name: "Variant A" },
+            ]);
+
+            mockGetAnalysis.mockImplementation((_experimentId, variantId) => {
+            if (variantId === 1) return { probabilityOfBeingBest: 0.05, conversionRate: 0.10 };
+            if (variantId === 2) return { probabilityOfBeingBest: 0.92, conversionRate: 0.18 };
+            });
+        });
+
+        it("throws if experimentId is missing", async () => {
+            await expect(sendSMSEnd(null, "My Experiment", "test.myshopify.com"))
+            .rejects.toThrow("experimentId is required");
+        });
+
+        it("throws if experimentName is missing", async () => {
+            await expect(sendSMSEnd(1, null, "test.myshopify.com"))
+            .rejects.toThrow("experimentName is required");
+        });
+
+        it("throws if shop is missing", async () => {
+            await expect(sendSMSEnd(1, "My Experiment", null))
+            .rejects.toThrow("shop is required");
+        });
+
+        it("publishes SMS end message to AWS_TOPIC_SMS without Subject and includes winner summary", async () => {
+            const response = await sendSMSEnd(1, "My Experiment", "test.myshopify.com");
+
+            expect(mockSend).toHaveBeenCalledOnce();
+            const sentCommand = mockSend.mock.calls[0][0];
+
+            expect(sentCommand.__type).toBe("PublishCommand");
+            expect(sentCommand.input.TopicArn).toBe(process.env.AWS_TOPIC_SMS);
+            expect(sentCommand.input.Message).toContain("Variant A has won");
+            expect(sentCommand.input.Subject).toBeUndefined();
+            expect(response).toEqual({ MessageId: "mock-message-id-123" });
+        });
+
+        it("uses Inconclusive when no winner exists", async () => {
+            mockGetAnalysis.mockImplementation((_experimentId, variantId) => {
+            if (variantId === 1) return { probabilityOfBeingBest: 0.45, conversionRate: 0.10 };
+            if (variantId === 2) return { probabilityOfBeingBest: 0.55, conversionRate: 0.11 };
+            });
+
+            await sendSMSEnd(1, "My Experiment", "test.myshopify.com");
+
+            const sentCommand = mockSend.mock.calls[0][0];
+            expect(sentCommand.input.Message).toContain("Inconclusive");
+        });
+    });
+
+    //unsubscribeAllPhoneNums feature
+    describe("unsubscribeAllPhoneNums", () => {
+        it("removes all confirmed phone subscriptions across pages", async () => {
+            mockSend
+            .mockResolvedValueOnce({
+                Subscriptions: [
+                { Endpoint: "+19165550001", SubscriptionArn: "arn:p1" },
+                { Endpoint: "+19165550002", SubscriptionArn: "PendingConfirmation" },
+                ],
+                NextToken: "page-2",
+            })
+            .mockResolvedValueOnce({
+                Subscriptions: [
+                { Endpoint: "+19165550003", SubscriptionArn: "arn:p3" },
+                ],
+                NextToken: undefined,
+            })
+            .mockResolvedValueOnce({})
+            .mockResolvedValueOnce({});
+
+            const result = await unsubscribeAllPhoneNums();
+
+            expect(result).toEqual({ ok: true, removed: 2 });
+            expect(mockSend).toHaveBeenCalledTimes(4);
+            expect(mockSend.mock.calls[2][0].__type).toBe("UnsubscribeCommand");
+            expect(mockSend.mock.calls[2][0].input.SubscriptionArn).toBe("arn:p1");
+            expect(mockSend.mock.calls[3][0].input.SubscriptionArn).toBe("arn:p3");
+        });
+
+        it("returns zero removed when there are no phone subscriptions", async () => {
+            mockSend.mockResolvedValueOnce({
+            Subscriptions: [],
+            NextToken: undefined,
+            });
+
+            const result = await unsubscribeAllPhoneNums();
+
+            expect(result).toEqual({ ok: true, removed: 0 });
+            expect(mockSend).toHaveBeenCalledTimes(1);
+        });
+    });
+
+
 });

--- a/app/__tests__/notifications.test.js
+++ b/app/__tests__/notifications.test.js
@@ -20,8 +20,10 @@ import {
 const mockSend = vi.fn().mockResolvedValue({ MessageId: "mock-message-id-123" });
 vi.mock("@aws-sdk/client-sns", () => {
     class SNSClient {
-        constructor(config) { this.config = config; }
-        send = mockSend;
+        constructor(config) {
+            this.config = config;
+            this.send = mockSend;
+        }
     }
     class PublishCommand {
         constructor(input) { this.input = input; this.__type = "PublishCommand"; }

--- a/app/__tests__/project.server.test.js
+++ b/app/__tests__/project.server.test.js
@@ -18,12 +18,17 @@ vi.mock("../db.server", () => {
 
 let setEmailNotifToggle;
 let getEmailNotifToggle;
+let setSMSNotifToggle;
+let getSMSNotifToggle;
 
 beforeAll(async () => {
   //Adjust to your real module location
   const mod = await import("../services/project.server.js");
   setEmailNotifToggle = mod.setEmailNotifToggle;
   getEmailNotifToggle = mod.getEmailNotifToggle;
+  setSMSNotifToggle = mod.setSMSNotifToggle;
+  getSMSNotifToggle = mod.getSMSNotifToggle;
+  
 });
 
 describe("project.server.js", () => {
@@ -114,5 +119,88 @@ describe("project.server.js", () => {
     findUniqueMock.mockRejectedValue(new Error("DB read failed"));
 
     await expect(getEmailNotifToggle(1)).rejects.toThrow("DB read failed");
+  });
+
+  it("setSMSNotifToggle updates smsNotifEnabled for the default project_id=1", async () => {
+  const fakeUpdatedProject = { id: 1, smsNotifEnabled: true };
+  updateMock.mockResolvedValue(fakeUpdatedProject);
+
+  const result = await setSMSNotifToggle(true); // project_id defaults to 1
+
+  expect(updateMock).toHaveBeenCalledTimes(1);
+  expect(updateMock).toHaveBeenCalledWith({
+    where: { id: 1 },
+    data: { smsNotifEnabled: true },
+  });
+
+  expect(result).toEqual(fakeUpdatedProject);
+  });
+
+  it("setSMSNotifToggle updates smsNotifEnabled for a provided project_id", async () => {
+    const fakeUpdatedProject = { id: 7, smsNotifEnabled: false };
+    updateMock.mockResolvedValue(fakeUpdatedProject);
+
+    const result = await setSMSNotifToggle(false, 7);
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(updateMock).toHaveBeenCalledWith({
+      where: { id: 7 },
+      data: { smsNotifEnabled: false },
+    });
+
+    expect(result).toEqual(fakeUpdatedProject);
+  });
+
+  it("setSMSNotifToggle propagates db errors", async () => {
+    updateMock.mockRejectedValue(new Error("DB update failed"));
+
+    await expect(setSMSNotifToggle(true, 1)).rejects.toThrow("DB update failed");
+  });
+
+  it("getSMSNotifToggle returns the boolean value when project exists (default notifId=1)", async () => {
+    findUniqueMock.mockResolvedValue({ smsNotifEnabled: true });
+
+    const result = await getSMSNotifToggle(); // defaults to 1
+
+    expect(findUniqueMock).toHaveBeenCalledTimes(1);
+    expect(findUniqueMock).toHaveBeenCalledWith({
+      where: { id: 1 },
+      select: { smsNotifEnabled: true },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("getSMSNotifToggle returns false when project exists and toggle is false", async () => {
+    findUniqueMock.mockResolvedValue({ smsNotifEnabled: false });
+
+    const result = await getSMSNotifToggle(3);
+
+    expect(findUniqueMock).toHaveBeenCalledTimes(1);
+    expect(findUniqueMock).toHaveBeenCalledWith({
+      where: { id: 3 },
+      select: { smsNotifEnabled: true },
+    });
+
+    expect(result).toBe(false);
+  });
+
+  it("getSMSNotifToggle returns null and logs when project is not found", async () => {
+    findUniqueMock.mockResolvedValue(null);
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    const result = await getSMSNotifToggle(999);
+
+    expect(findUniqueMock).toHaveBeenCalledTimes(1);
+    expect(result).toBeNull();
+    expect(logSpy).toHaveBeenCalledWith("Failed to find getSMSNotifToggle() value");
+
+    logSpy.mockRestore();
+  });
+
+  it("getSMSNotifToggle propagates db errors", async () => {
+    findUniqueMock.mockRejectedValue(new Error("DB read failed"));
+
+    await expect(getSMSNotifToggle(1)).rejects.toThrow("DB read failed");
   });
 });

--- a/app/routes/api.cron.poll-experiments.jsx
+++ b/app/routes/api.cron.poll-experiments.jsx
@@ -68,7 +68,7 @@ export async function loader({ request }) {
       let start_results = [];
       let end_results = [];
       let failures = [];
-      const { sendEmailStart } = await import("../services/notifications.server");
+      const { sendEmailStart, sendSMSEnd, sendSMSStart } = await import("../services/notifications.server");
       const { sendEmailEnd } = await import("../services/notifications.server");
       if (started_experiments.length > 0 ) {
         for (const experiment of started_experiments) {
@@ -79,12 +79,16 @@ export async function loader({ request }) {
             //check if starting of experiment notifications is enabled
             const project = await db.project.findUnique({
                 where: { id: experiment.projectId },
-                select: { enableExperimentStart: true, shop: true }
+                select: { enableExperimentStart: true, emailNotifEnabled: true, smsNotifEnabled: true,  shop: true }
             });
 
-            //send the email if enabled
-            if (project?.enableExperimentStart) {
+            //send the email and sms if enabled
+            if (project?.enableExperimentStart && project?.emailNotifEnabled) {
                 await sendEmailStart(experiment.id, experiment.name, project.shop);
+            }
+            if (project?.enableExperimentStart && project?.smsNotifEnabled)
+            {
+              await sendSMSStart(experiment.id, experiment.name, project.shop);
             }
           }catch(e){
             failures.push(e.message);
@@ -99,12 +103,16 @@ export async function loader({ request }) {
             //check if ending of experiment notifications is enabled
             const project = await db.project.findUnique({
                 where: { id: experiment.projectId },
-                select: { enableExperimentEnd: true, shop: true }
+                select: { enableExperimentEnd: true,  emailNotifEnabled: true, smsNotifEnabled: true,  shop: true }
             });
 
-            //send the email if enabled
-            if (project?.enableExperimentEnd) {
+            //send the email and sms once experiment completes if enabled in settings
+            if (project?.enableExperimentEnd && project?.emailNotifEnabled) {
                 await sendEmailEnd(experiment.id, experiment.name, project.shop);
+            }
+            if (project?.enableExperimentEnt && project?.smsNotifEnabled)
+            {
+              await sendSMSEnd(experiment.id, experiment.name, project.shop);
             }
           }catch(e){
             failures.push(e.message);

--- a/app/routes/app.settings.jsx
+++ b/app/routes/app.settings.jsx
@@ -13,6 +13,8 @@ export const loader = async ({ request }) => {
     create: { shop: session.shop, name: `${session.shop} Project`, defaultGoal: "completedCheckout" },
     select: {
       defaultGoal: true,
+      smsNotifEnabled: true,
+      emailNotifEnabled: true,
       enableExperimentStart: true,
       enableExperimentEnd: true,
       maxUsersPerExperiment: true,
@@ -25,11 +27,6 @@ export const loader = async ({ request }) => {
   const { getTutorialData } = await import ("../services/tutorialData.server");
   const tutorialInfo = await getTutorialData();
 
-  //import email and sms toggle notification preset data. 
-  const { getEmailNotifToggle, getSMSNotifToggle } = await import ("../services/project.server");
-  const emailStatus = await getEmailNotifToggle();
-  const smsStatus = await getSMSNotifToggle();
-        
   return {
     defaultGoal: project.defaultGoal,
     enableExperimentStart: project.enableExperimentStart,
@@ -38,8 +35,8 @@ export const loader = async ({ request }) => {
     contactEmails: project.contactEmails,
     contactPhones: project.contactPhones,
     tutorialData: tutorialInfo,
-    emailNotifEnabled: emailStatus,
-    smsNotifEnabled: smsStatus
+    emailNotifEnabled: project.emailNotifEnabled,
+    smsNotifEnabled: project.smsNotifEnabled
   };
 };
 
@@ -70,6 +67,11 @@ export const action = async ({ request }) => {
       console.error("SMS toggle value change was invalid: ", error);
       return { ok: false, error: "failed to change sms toggle to true" };
     }
+    await db.project.update({
+      where: { shop: session.shop },
+      data: { smsNotifEnabled: true },
+    });
+    return { ok: true, intent: "set_sms_notif_true" };
   }
   else if (intent == "set_sms_notif_false")
   {
@@ -82,6 +84,11 @@ export const action = async ({ request }) => {
       console.error("SMS toggle value change was invalid: ", error);
       return { ok: false, error: "failed to sms toggle to false" };
     }
+    await db.project.update({
+      where: { shop: session.shop },
+      data: { smsNotifEnabled: false },
+    });
+    return { ok: true, intent: "set_sms_notif_false" };
   }
   else if( intent === "set_email_notif_false")
   {
@@ -92,9 +99,17 @@ export const action = async ({ request }) => {
       console.error("Email toggle value change was invalid: ", error)
       return { ok: false, error: "failed to change email toggle" }; 
     }
+
+    await db.project.update({
+      where: { shop: session.shop },
+      data: { emailNotifEnabled: false },
+    });
+    return { ok: true, intent: "set_email_notif_false" };
+
   }
   else if (intent === "set_email_notif_true")
   {
+      
     //actual notification toggle update
     try {
       const { setEmailNotifToggle} = await import ("../services/project.server");
@@ -105,26 +120,13 @@ export const action = async ({ request }) => {
       return {ok: false, error: "failed to change email toggle"};
     }
     //function and commands that send email on experiment start (for testing purposes)
-    try {
-      const { sendEmailStart } = await import ("../services/notifications.server");
-      await sendEmailStart(); 
-    }
-    catch (error) {
-      console.error("Email Notification Toggle Error: ", error);
-      return {ok: false, error: "failed to send email"};
-    } 
 
-    //function and commands that send email on experiment end (for testing purposes)
-    try {
-      const { sendEmailEnd } = await import ("../services/notifications.server");
-      await sendEmailEnd(); 
-    }
-    catch (error) {
-      console.error("Email Notification Toggle Error: ", error);
-      return {ok: false, error: "failed to send email"};
-    } 
-    
-    
+    //db query update to adjust proper store associated
+    await db.project.update({
+      where: { shop: session.shop },
+      data: { emailNotifEnabled: true },
+    });
+      return { ok: true, intent: "set_email_notif_true" };
   }
 
   if(intent === "tutorial_viewed")
@@ -344,7 +346,7 @@ export default function Settings() {
 
   //notification toggle fields
   const [emailEnabled, setEmailEnabled] = useState(emailNotifEnabled);
-  const [smsEnabled, setSMSEnabled] = useState(false);
+  const [smsEnabled, setSMSEnabled] = useState(smsNotifEnabled);
   //string show ties in with emailEnabled variable
   const emailNotifToggleDetails = emailEnabled
     ? 'Notifications enabled'

--- a/app/routes/app.settings.jsx
+++ b/app/routes/app.settings.jsx
@@ -25,9 +25,10 @@ export const loader = async ({ request }) => {
   const { getTutorialData } = await import ("../services/tutorialData.server");
   const tutorialInfo = await getTutorialData();
 
-  //import email toggle notification preset data. 
-  const { getEmailNotifToggle } = await import ("../services/project.server");
+  //import email and sms toggle notification preset data. 
+  const { getEmailNotifToggle, getSMSNotifToggle } = await import ("../services/project.server");
   const emailStatus = await getEmailNotifToggle();
+  const smsStatus = await getSMSNotifToggle();
         
   return {
     defaultGoal: project.defaultGoal,
@@ -37,7 +38,8 @@ export const loader = async ({ request }) => {
     contactEmails: project.contactEmails,
     contactPhones: project.contactPhones,
     tutorialData: tutorialInfo,
-    emailNotifEnabled: emailStatus
+    emailNotifEnabled: emailStatus,
+    smsNotifEnabled: smsStatus
   };
 };
 
@@ -57,6 +59,30 @@ export const action = async ({ request }) => {
     });
     return { ok: true, intent: "updateDefaultGoal", defaultGoal };
   }
+  else if (intent === "set_sms_notif_true")
+  {
+    console.log("performed sms true action");
+    try {
+      const {setSMSNotifToggle} = await import ("../services/project.server");
+      await setSMSNotifToggle(true);
+    } catch (error)
+    {
+      console.error("SMS toggle value change was invalid: ", error);
+      return { ok: false, error: "failed to change sms toggle to true" };
+    }
+  }
+  else if (intent == "set_sms_notif_false")
+  {
+    console.log("performed sms false action");
+    try {
+      const {setSMSNotifToggle} = await import ("../services/project.server");
+      await setSMSNotifToggle(false);
+    } catch (error)
+    {
+      console.error("SMS toggle value change was invalid: ", error);
+      return { ok: false, error: "failed to sms toggle to false" };
+    }
+  }
   else if( intent === "set_email_notif_false")
   {
     try {
@@ -64,7 +90,7 @@ export const action = async ({ request }) => {
         await setEmailNotifToggle(false)
     } catch (error) {
       console.error("Email toggle value change was invalid: ", error)
-      return { ok: false, error: "failed to change email toggle" }; // also fix comma operator    
+      return { ok: false, error: "failed to change email toggle" }; 
     }
   }
   else if (intent === "set_email_notif_true")
@@ -119,11 +145,6 @@ export const action = async ({ request }) => {
 
     const email = (formData.get("email") || "").trim().toLowerCase();
 
-    const {subscribeEmail} = await import ("../services/notifications.server");
-    const emailSubStatus= await subscribeEmail(email);
-    console.log("email subscribed: " + emailSubStatus);
-
-
     //check if empty
     if (!email) return { error: "Email cannot be null", field: "email" };
     //check entry matches format xxx@xxx.xxx
@@ -143,6 +164,12 @@ export const action = async ({ request }) => {
     if (existing) return { error: "Provided email is already saved", field: "email" };
 
     await db.contactEmail.create({ data: { email, projectId: project.id } });
+
+    //adds email to aws
+    const {subscribeEmail} = await import ("../services/notifications.server");
+    const emailSubStatus= await subscribeEmail(email);
+    console.log("email subscribed: " + emailSubStatus);
+
     return { ok: true };
   }
 
@@ -150,7 +177,7 @@ export const action = async ({ request }) => {
   if (intent === "deleteEmail") {
     const email = formData.get("email");
     const {unsubscribeEmail} = await import ("../services/notifications.server");
-    const unsubStatus = await unsubscribeEmail(email);
+    await unsubscribeEmail(email);
 
     const id = parseInt(formData.get("id"), 10);
     await db.contactEmail.delete({ where: { id } });
@@ -183,20 +210,31 @@ export const action = async ({ request }) => {
     if (existing) return { error: "Provided phone number is already saved", field: "phone" };
 
     await db.contactPhone.create({ data: { phoneNumber, projectId: project.id } });
+
+    //add the valid phone number to aws reporting
+    const {subscribePhoneNum} = await import ("../services/notifications.server");
+    await subscribePhoneNum(phoneNumber);
+
     return { ok: true };
   }
 
   //delete a phone number from the list
   if (intent === "deletePhone") {
+    //unsubscribes number from aws
+    const unsubNum = formData.get("phoneNumber"); // double check syntax
+    const {unsubscribePhoneNum} = await import ("../services/notifications.server");
+    await unsubscribePhoneNum(unsubNum);
+
     const id = parseInt(formData.get("id"), 10);
     await db.contactPhone.delete({ where: { id } });
     return { ok: true };
   }
 
   if (intent === "deleteAll") {
-    //performs notification function to unsubscribe everyone associated with the topic
-    const {unsubscribeAll} = await import ("../services/notifications.server");
+    //performs notification function to unsubscribe everyone associated with the email topic
+    const {unsubscribeAll, unsubscribeAllPhoneNums} = await import ("../services/notifications.server");
     const res = await unsubscribeAll();
+    const res2 = await unsubscribeAllPhoneNums()
 
     //locate the project
     const project = await db.project.findUnique({
@@ -267,7 +305,7 @@ function formatPhone(digits) {
 }
 
 export default function Settings() {
-  const { defaultGoal, enableExperimentStart, enableExperimentEnd, maxUsersPerExperiment, contactEmails, contactPhones, tutorialData, emailNotifEnabled } = useLoaderData();
+  const { defaultGoal, enableExperimentStart, enableExperimentEnd, maxUsersPerExperiment, contactEmails, contactPhones, tutorialData, emailNotifEnabled, smsNotifEnabled } = useLoaderData();
   const fetcher = useFetcher();
   const goalFetcher = useFetcher();
   const maxUsersFetcher = useFetcher();
@@ -306,8 +344,12 @@ export default function Settings() {
 
   //notification toggle fields
   const [emailEnabled, setEmailEnabled] = useState(emailNotifEnabled);
+  const [smsEnabled, setSMSEnabled] = useState(false);
   //string show ties in with emailEnabled variable
   const emailNotifToggleDetails = emailEnabled
+    ? 'Notifications enabled'
+    : 'Notifications disabled';
+  const smsNotifToggleDetails = smsEnabled
     ? 'Notifications enabled'
     : 'Notifications disabled';
 
@@ -330,6 +372,31 @@ export default function Settings() {
       console.log('disabled email notifications')
       fetcher.submit(
         {intent: "set_email_notif_false"},
+        {method: "put"}
+      )
+    }
+  }
+
+  
+  function handleSMSNotificationToggle(event){
+    const notifToggleType = event.currentTarget.checked;
+    setSMSEnabled(event.currentTarget.checked);
+    if (notifToggleType)
+    {
+      //Shoud be put since it is a notification change? 
+      console.log('disabled SMS Notifications')
+      fetcher.submit(
+        {intent: "set_sms_notif_true"},
+        {method: "put"}
+      )
+      console.log('enabled e-mail notifications');
+      //call complex function here
+    }
+    else
+    {
+      console.log('disabled SMS Notifications')
+      fetcher.submit(
+        {intent: "set_sms_notif_false"},
         {method: "put"}
       )
     }
@@ -407,12 +474,10 @@ export default function Settings() {
   //handler functions
   const handleAddEmail = () => {fetcher.submit({ intent: "addEmail", email: emailInput }, { method: "post" });};
   const handleAddPhone = () => {fetcher.submit({ intent: "addPhone", phone: phoneInput }, { method: "post" });};
-  const handleDeletePhone = (id) => {fetcher.submit({ intent: "deletePhone", id: String(id)}, { method: "post" });};
+  const handleDeletePhone = (id, phoneNumber) => {fetcher.submit({ intent: "deletePhone", id: String(id), phoneNumber}, { method: "post" });};
   const handleDeleteAllContact = () => {fetcher.submit({ intent: "deleteAll" }, { method: "post" });};  
-  
   const handleDeleteEmail = (id, email) => {
     fetcher.submit({ intent: "deleteEmail", id: String(id), email }, { method: "post" });
-  
   };
 
   const handleSaveDefaultGoal = () => {
@@ -551,7 +616,7 @@ export default function Settings() {
                         {contactPhones.map((entry) => (
                           <s-clickable-chip
                             key={entry.id}
-                            onClick={() => handleDeletePhone(entry.id)}
+                            onClick={() => handleDeletePhone(entry.id, entry.phoneNumber)}
                             onMouseEnter={() => setHoveredPhoneId(entry.id)}
                             onMouseLeave={() => setHoveredPhoneId(null)}
                           >
@@ -573,13 +638,22 @@ export default function Settings() {
             </s-grid-item>
             <s-grid-item>
               <s-switch
+                  id="SMS-notif-toggle"
+                  label="Enable SMS Notifications"
+                  details= {smsNotifToggleDetails}
+                  checked={smsEnabled}
+                  onChange={handleSMSNotificationToggle}
+                  error = "SMS Notifications for AWS may not have been configured. Enabling may cause errors."
+                  >
+              </s-switch>
+              <s-switch
                     id="email-notif-toggle"
                     label="Enable E-mail Notifications"
                     details= {emailNotifToggleDetails}
                     checked={emailEnabled}
                     onChange={handleEmailNotificationToggle}
                     >
-                    Enable E-mail Notifications</s-switch>
+              </s-switch>
               <s-stack direction="block" gap="base">
                 {/*right side, button cluster*/}
                 <div style={{ margin: "10px 0" }}>

--- a/app/services/notifications.server.js
+++ b/app/services/notifications.server.js
@@ -128,24 +128,6 @@ export async function subscribeEmail(email) {
   return response;
 }
 
-//subscribes phone number input param must follow e.164 format (ex. +19166666666)
-export async function subscribePhone(phoneNumber) {
-  const sns = new SNSClient({
-    region: process.env.AWS_REGION,
-  });
-
-  const command = new SubscribeCommand({
-    TopicArn: process.env.AWS_TOPIC,
-    Protocol: "sms",
-    Endpoint: phoneNumber,
-  });
-
-  const response = await sns.send(command);
-
-  console.log("Subscription response:", response.SubscriptionArn);
-  return response;
-}
-
 //unsubscirbe function to remove emails from our specified topic. 
 export async function unsubscribeEmail(email) {
   const sns = new SNSClient({
@@ -197,7 +179,7 @@ export async function unsubscribeEmail(email) {
     new UnsubscribeCommand({ SubscriptionArn: subscriptionArn})
   );
   console.log("unsubscribe of " + email + " successful")
-}// end unsubscribeEmail
+} // end unsubscribeEmail
 
 
 export async function unsubscribeAll() {
@@ -283,4 +265,236 @@ export function determineWinner(analysis) {
     );
     const label = VARIANT_LABELS[topWinner.variantName] ?? topWinner.variantName;
     return `Variant ${label} has won`;
+}
+
+// ------------------------SMS functions -----------------------------
+
+//subscribes phone number input params are assumed to be 10 digits
+export async function subscribePhoneNum(phoneNumber) {
+
+  //error check for formatting
+  if (phoneNumber.length != 10)
+  {
+    throw new Error("invalid phone number format");
+  }
+
+  //reformats to be e.164 compliant, assumes input is 10 digits
+  phoneNumber = `+1${phoneNumber}`;
+  
+  const sns = new SNSClient({
+    region: process.env.AWS_REGION,
+  });
+
+  const command = new SubscribeCommand({
+    TopicArn: process.env.AWS_TOPIC_SMS,
+    Protocol: "sms",
+    Endpoint: phoneNumber,
+  });
+
+  const response = await sns.send(command);
+
+  console.log("Phone subscription response:" + response.SubscriptionArn + ' httpStatusCode:' + response.httpStatusCode);
+  return response;
+}
+
+//unsub function to remove phone number  from our specified topic. 
+export async function unsubscribePhoneNum(phoneNum) {
+
+  //error check for formatting
+  if (phoneNum.length != 10)
+  {
+    throw new Error("invalid phone number format");
+  }
+
+  //reformats to be e.164 compliant, assumes input is 10 digits
+  phoneNum = `+1${phoneNum}`;
+  
+  const sns = new SNSClient({
+    region: process.env.AWS_REGION,
+  });
+
+  //queries particular AWS topic for list of emails 
+
+
+  //searching through list of subscribers. 
+  let nextToken = undefined;
+  let subscriptionArn = null;
+
+  //performs loop to search for subscribers since aws only returns first 100. 
+  do {
+    const response = await sns.send(
+      new ListSubscriptionsByTopicCommand({
+        TopicArn: process.env.AWS_TOPIC_SMS,
+        NextToken: nextToken //loads 
+      })
+    );
+
+    const sub = response.Subscriptions?.find(
+      s => s.Endpoint === phoneNum
+    );
+
+    if (sub) {
+      subscriptionArn = sub.SubscriptionArn;
+      break;
+    }
+
+    nextToken = response.NextToken; //gives nextToken relevant value (null when no more subscribers) 
+
+  } while (nextToken); //runs until nextToken is not null
+
+  //fail case for finding no matching email or finding email that has not clicked 'subscribe' email
+  if(subscriptionArn === "PendingConfirmation")
+  {
+    console.log("unsubscribe number is pending.");
+    return;
+  }
+  if (!subscriptionArn)
+  {
+    console.log("unsubscribe number was invalid");
+    return;
+  }
+
+  const response = await sns.send(
+    new UnsubscribeCommand({ SubscriptionArn: subscriptionArn})
+  );
+  console.log(`unsubcribe succesful: ${response.$metadata.requestId} httpStatusCode: ${response.$metadata.httpStatusCode}`);
+} // end unsub phoneNum
+
+//sends a SMS text on experiment end
+export async function sendSMSEnd(experimentId, experimentName, shop)
+{
+    //error handling
+    if (!experimentId) {
+        throw new Error("sendSMSEnd: experimentId is required");
+    }
+    if (!experimentName) {
+        throw new Error("sendSMSEnd: experimentName is required");
+    }
+    if (!shop) {
+        throw new Error("sendSMSEnd: shop is required");
+    }
+
+    //fetch analysis for determining winner
+    const { getVariants } = await import("../services/variant.server"); 
+    const variants = await getVariants(experimentId); //fetch variants for experiment
+    const { getAnalysis } = await import("../services/experiment.server");
+    
+    //fetch analysis for all experiments (including mobile and desktop)
+    const analysisResults = await Promise.all(
+        variants.map(async (v) => {
+            const a = await getAnalysis(experimentId, v.id, "all");
+            //if no analysis, return null
+            if (!a) return null;
+            //return all analysises, and also the variant name
+            return { ...a, variantName: v.name };
+        })
+    );
+
+    //drops null entries (if a variant has no analysis it gets excluded)
+    const analysis = analysisResults.filter(Boolean);
+
+    const winnerSummary = determineWinner(analysis);
+
+    console.log(`inside sendSMSStart()`);
+    const sns = new SNSClient({
+        region: process.env.AWS_REGION,
+    }); 
+
+    const message = formatExperimentCompleted({
+        experimentName,
+        experimentId,
+        shop,
+        winnerSummary,
+    });
+
+    if (!message?.emailBody || !message?.subject) {
+        throw new Error("sendSMSEnd: message formatting failed, emailBody or subject is missing");
+    }
+    //contains message sent, subject line and ARN
+    //ARN is the unique identifier for the designated 'topic' that will contain everyone receiving the message
+    //note: currently uses mail body (may not be optimal formatting)
+    const command = new PublishCommand({
+        TopicArn: process.env.AWS_TOPIC_SMS,
+        Message: message.emailBody, 
+    });
+
+    const response = await sns.send(command);
+    console.log(`sendEmailStart: SMS sent successfully, MessageId: ${response.MessageId} httpStatusCode: ${response.httpStatusCode}`);
+    return response;
+}
+
+export async function sendSMSStart(experimentId, experimentName, shop)
+{
+    //error handling
+    if (!experimentId) {
+        throw new Error("sendSMSStart: experimentId is required");
+    }
+    if (!experimentName) {
+        throw new Error("sendSMSStart: experimentName is required");
+    }
+    if (!shop) {
+        throw new Error("sendSMSStart: shop is required");
+    }
+
+    console.log(`inside sendEmailStart()`);
+    const sns = new SNSClient({
+        region: process.env.AWS_REGION,
+    });
+
+    const message = formatExperimentStarted({
+        experimentName,
+        experimentId,
+        shop,
+    });
+
+    if (!message?.emailBody || !message?.subject) {
+        throw new Error("sendSMSStart: message formatting failed, emailBody or subject is missing");
+    }
+    //contains message sent, subject line and ARN
+    //ARN is the unique identifier for the designated 'topic' that will contain everyone receiving the message
+    //email body may not be optimal formatting for SMS
+    const command = new PublishCommand({
+        TopicArn: process.env.AWS_TOPIC_SMS,
+        Message: message.emailBody
+    });
+
+    const response = await sns.send(command);
+    console.log(`sendSMSStart: SMS sent successfully, MessageId: ${response.MessageId} httpStatusCode: ${response.httpStatusCode}`);
+    return response;
+}
+
+//created distinct topic in AWS that will hold phone numbers for scheduled reporting, function removes phone nums from that specified topic. 
+export async function unsubscribeAllPhoneNums() {
+  const sns = new SNSClient({ region: process.env.AWS_REGION });
+  const topicArn = process.env.AWS_TOPIC_SMS;
+  
+  let nextToken = undefined;
+  const arnsToRemove = [];
+
+  do {
+    const response = await sns.send(
+      new ListSubscriptionsByTopicCommand({
+        TopicArn: topicArn,
+        NextToken: nextToken,
+      })
+    );
+
+    for (const sub of response.Subscriptions || []) {
+      if (
+        sub.SubscriptionArn &&
+        sub.SubscriptionArn !== "PendingConfirmation" //avoids aws throwing an error, means the email has not accepted subscription
+      ) {
+        arnsToRemove.push(sub.SubscriptionArn);
+      }
+    }
+    nextToken = response.NextToken;
+  } while (nextToken);
+
+  for (const subscriptionArn of arnsToRemove) {
+    await sns.send(
+      new UnsubscribeCommand({ SubscriptionArn: subscriptionArn })
+    );
+  }
+
+  return { ok: true, removed: arnsToRemove.length };
 }

--- a/app/services/project.server.js
+++ b/app/services/project.server.js
@@ -36,4 +36,36 @@ export async function getEmailNotifToggle(notifId = 1) {
     } 
 }
 
+export async function getSMSNotifToggle(notifId = 1)
+{
+    const project = await db.project.findUnique({
+        where : {id:notifId},
+        select: {smsNotifEnabled:true},
+    });
+       
+    if (!project) {
+        console.log("Failed to find getSMSNotifToggle() value");
+        return null;
+    }
+    else
+    {
+        return project.smsNotifEnabled;
+    } 
+
+}
+
+export async function setSMSNotifToggle(setOn, project_id = 1)
+{
+    const updated = await db.project.update({
+            where: {
+                id : project_id
+            },
+            data:{
+                smsNotifEnabled : setOn
+            }
+    });
+
+    return updated;
+}
+
 

--- a/prisma/migrations/20260322023052_add_sms_email_notif_enabled_to_project/migration.sql
+++ b/prisma/migrations/20260322023052_add_sms_email_notif_enabled_to_project/migration.sql
@@ -1,0 +1,21 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Project" (
+    "project_id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "shop" TEXT NOT NULL,
+    "name" TEXT,
+    "created_at" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "default_goal" TEXT NOT NULL DEFAULT 'completedCheckout',
+    "max_users_per_experiment" INTEGER NOT NULL DEFAULT 10000,
+    "smsNotifEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "emailNotifEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "enableExperimentStart" BOOLEAN NOT NULL DEFAULT false,
+    "enableExperimentEnd" BOOLEAN NOT NULL DEFAULT false
+);
+INSERT INTO "new_Project" ("created_at", "default_goal", "emailNotifEnabled", "enableExperimentEnd", "enableExperimentStart", "max_users_per_experiment", "name", "project_id", "shop") SELECT "created_at", "default_goal", "emailNotifEnabled", "enableExperimentEnd", "enableExperimentStart", "max_users_per_experiment", "name", "project_id", "shop" FROM "Project";
+DROP TABLE "Project";
+ALTER TABLE "new_Project" RENAME TO "Project";
+CREATE UNIQUE INDEX "Project_shop_key" ON "Project"("shop");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -46,6 +46,7 @@ model Project {
 
   contactEmails ContactEmail[]
   contactPhones ContactPhone[]
+  smsNotifEnabled Boolean @default(false)
   emailNotifEnabled Boolean @default(false)
 
   //enable notifications for start and end of experiment


### PR DESCRIPTION
Current feature integrates reporting to work for SMS provided the user has configured their AWS account and `AWS_TOPIC` and `AWS_TOPIC_SMS`  secrets. Created toggles for receiving notifications and included them in the settings. 