### PR TITLE
properly referencing temp .env file to delete instead of real .env

### DIFF
--- a/app/__tests__/switch-db.test.js
+++ b/app/__tests__/switch-db.test.js
@@ -4,16 +4,22 @@ import { execSync } from "child_process";
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 
 const ENV_PATH = path.resolve(process.cwd(), ".env");
+const BACKUP_ENV_PATH = path.resolve(process.cwd(), ".env.backup.test");
 const CONFIG_PATH = path.resolve(process.cwd(), "config/db.environment.config.json");
 
 const TEST_ENV_CONTENT = `FOO=bar\nDATABASE_URL="file:./old.sqlite"\n`;
 
 describe("switch-db script", () => {
   beforeEach(() => {
-    // create fake .env
+    // backup real .env if it exists
+    if (fs.existsSync(ENV_PATH)) {
+      fs.copyFileSync(ENV_PATH, BACKUP_ENV_PATH);
+    }
+
+    // create test .env
     fs.writeFileSync(ENV_PATH, TEST_ENV_CONTENT, "utf8");
 
-    // create fake config
+    // create test config
     fs.mkdirSync(path.dirname(CONFIG_PATH), { recursive: true });
     fs.writeFileSync(
       CONFIG_PATH,
@@ -26,7 +32,16 @@ describe("switch-db script", () => {
   });
 
   afterEach(() => {
-    if (fs.existsSync(ENV_PATH)) fs.unlinkSync(ENV_PATH);
+    // restore original .env if it existed
+    if (fs.existsSync(BACKUP_ENV_PATH)) {
+      fs.copyFileSync(BACKUP_ENV_PATH, ENV_PATH);
+      fs.unlinkSync(BACKUP_ENV_PATH);
+    } else {
+      // if no original, remove test file
+      if (fs.existsSync(ENV_PATH)) fs.unlinkSync(ENV_PATH);
+    }
+
+    // cleanup config
     if (fs.existsSync(CONFIG_PATH)) fs.unlinkSync(CONFIG_PATH);
   });
 
@@ -36,7 +51,7 @@ describe("switch-db script", () => {
     const env = fs.readFileSync(ENV_PATH, "utf8");
 
     expect(env).toContain(`DATABASE_URL="file:./dev.sqlite"`);
-    expect(env).toContain(`FOO=bar`); // ensures we didn’t wipe file
+    expect(env).toContain(`FOO=bar`);
   });
 
   it("updates DATABASE_URL to test", () => {


### PR DESCRIPTION
Bug fix for test deleting real .env file instead of temp .env file