### PR TITLE
Update shopify.app.prod.toml

### DIFF
--- a/shopify.app.prod.toml
+++ b/shopify.app.prod.toml
@@ -21,7 +21,7 @@ api_version = "2026-01"
 
 [access_scopes]
 # Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
-scopes = "read_reports,read_products,write_products,write_products, write_pixels, read_customer_events"
+scopes = "read_themes,read_reports,read_products,write_products,write_products, write_pixels, read_customer_events"
 
 [auth]
 redirect_urls = [


### PR DESCRIPTION
the read_themes permission was added to access scopes in the shopify prod toml file so that our app can verify that the app embed verification button is working in production