### PR TITLE
Et 691 graph feature

### DIFF
--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -563,18 +563,19 @@ export default function Index() {
                     />
                     <Tooltip />
                     <Legend />
-                        {experiment.variants.map((v, index) => {
-                          const colors = ["#5C6AC4", "#9C6ADE", "#00A0AC", "#FFC447"];
-                          return (
-                            <Line
-                              key={v.id}
-                              type="monotone"
-                              dataKey={v.name}
-                              stroke={colors[index % colors.length]}
-                              activeDot={{ r: 8 }}
-                              dot={false}
-                            />
-                          );
+                      {experiment.variants.map((v, index) => {
+                        const colors = ["#0072B2", "#009E73", "#E69F00", "#D55E00"];
+                        return (
+                          <Line
+                            key={v.id}
+                            type="monotone"
+                            dataKey={v.name}
+                            stroke={colors[index % colors.length]}
+                            activeDot={{ r: 8 }}
+                            strokeWidth={2}
+                            dot={false}
+                          />
+                        );
                         })}
                       </LineChart>
                     </ResponsiveContainer>

--- a/app/routes/app.reports.$id.jsx
+++ b/app/routes/app.reports.$id.jsx
@@ -768,13 +768,14 @@ export default function Report() {
               <Tooltip formatter={(value) => `${(value * 100).toFixed(2)}%`} />
               <Legend />
               {experiment.variants.map((v, index) => {
-                const colors = ["#5C6AC4", "#9C6ADE", "#00A0AC", "#FFC447"];
+                const colors = ["#0072B2", "#009E73", "#E69F00", "#D55E00"];
                 return (
                   <Line
                     key={v.id}
                     type="monotone"
                     dataKey={v.name}
                     stroke={colors[index % colors.length]}
+                    strokeWidth={2}
                     activeDot={{ r: 8 }}
                     dot={false}
                   />

--- a/app/routes/app.reports.$id.jsx
+++ b/app/routes/app.reports.$id.jsx
@@ -718,13 +718,14 @@ export default function Report() {
                 label={{ value: '80% Threshold', position: 'right', fill: '#2c2d2c', fontSize: 10 }}
               />
               {experiment.variants.map((v, index) => {
-                const colors = ["#5C6AC4", "#9C6ADE", "#00A0AC", "#FFC447"];
+                const colors = ["#0072B2", "#009E73", "#E69F00", "#D55E00"];
                 return (
                   <Line
                     key={v.id}
                     type="monotone"
                     dataKey={v.name}
                     stroke={colors[index % colors.length]}
+                    strokeWidth={2}
                     activeDot={{ r: 8 }}
                     dot={false}
                   />


### PR DESCRIPTION
Adjustments to all graphs to improve readability. Selected a higher contrast, and red/green colorblindness friendly options. No additional setup should be required, simply ensure your .env is up to date. 