### PR TITLE
App Crash Filter Fix

### DIFF
--- a/app/__tests__/Pagination.test.jsx
+++ b/app/__tests__/Pagination.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { vi, describe, it, expect, beforeEach } from 'vitest';
 import { useLoaderData } from 'react-router';
 import Reports from '../routes/app.reports._index';
@@ -237,10 +237,10 @@ describe('Experimentsindex — Pagination', () => {
     expect(screen.getByRole('button', { name: 'Previous' })).toBeDisabled();
   });
 
-  it('navigates to page 2 when Next is clicked', () => {
+  it('navigates to page 2 when Next is clicked', async () => {
     render(<Experimentsindex />);
     fireEvent.click(screen.getByRole('button', { name: 'Next' }));
-    expect(screen.getByText('Experiment 4')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Experiment 4')).toBeInTheDocument());
     expect(screen.getByText('Experiment 1')).toBeInTheDocument();
     expect(screen.queryByText('Experiment 20')).not.toBeInTheDocument();
   });
@@ -292,10 +292,10 @@ describe('Experimentsindex — Filter + Pagination', () => {
     expect(screen.getByText(/of 10/)).toBeInTheDocument();
   });
 
-  it('filtering by active shows only active experiments', () => {
+  it('filtering by active shows only active experiments', async () => {
     render(<Experimentsindex />);
     fireEvent.click(screen.getByRole('button', { name: 'Active' }));
-    expect(screen.getByText('Experiment 19')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Experiment 19')).toBeInTheDocument());
     expect(screen.queryByText('Experiment 20')).not.toBeInTheDocument();
   });
 
@@ -306,14 +306,13 @@ describe('Experimentsindex — Filter + Pagination', () => {
     expect(screen.getByText(/of 20/)).toBeInTheDocument();
   });
 
-  it('pagination resets correctly after filter change', () => {
+  it('pagination resets correctly after filter change', async () => {
     render(<Experimentsindex />);
     fireEvent.click(screen.getByRole('button', { name: 'Next' }));
-    expect(screen.getByText('Experiment 4')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Experiment 4')).toBeInTheDocument());
 
     fireEvent.click(screen.getByRole('button', { name: 'Active' }));
-
-    expect(screen.getByText('Experiment 19')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('Experiment 19')).toBeInTheDocument());
     expect(screen.queryByText('Experiment 4')).not.toBeInTheDocument();
   });
 

--- a/app/routes/app.experiments._index.jsx
+++ b/app/routes/app.experiments._index.jsx
@@ -1,5 +1,5 @@
 import { useLoaderData, useFetcher, useRevalidator } from "react-router";
-import { useEffect, useRef, useState, useMemo } from "react";
+import { useEffect, useRef, useState, useMemo, useCallback } from "react";
 //import Decimal from 'decimal.js';
 import { formatRuntime } from "../utils/formatRuntime.js";
 import { formatImprovement } from "../utils/formatImprovement.js";
@@ -323,6 +323,14 @@ export default function Experimentsindex() {
   //pagination elements
   const { currentPage, setCurrentPage, totalPages, startIndex, paginatedItems: paginatedExperiments } =
     usePagination(sortedExperiments, 16);
+
+  //firefox fix: frame delay before table update
+  //allow new components to mount before cleanup postMessage is sent (was causing the crash)
+  const [displayedExperiments, setDisplayedExperiments] = useState(paginatedExperiments);
+  useEffect(() => {
+    const id = setTimeout(() => setDisplayedExperiments(paginatedExperiments), 0);
+    return () => clearTimeout(id);
+  }, [paginatedExperiments]);
   //check for errors after rename attempt
   useEffect(() => {
     if (fetcher.state === "idle" && fetcher.data?.action === "rename_error") {
@@ -791,7 +799,7 @@ export default function Experimentsindex() {
                 {/*Place Quick Access Button here */}
               </s-table-header-row>
               <s-table-body>
-                {renderTableData(paginatedExperiments)}
+                {renderTableData(displayedExperiments)}
                 {/* function call that returns the jsx data for table rows */}
               </s-table-body>
             </s-table>


### PR DESCRIPTION
This was found to be a Firefox specific bug (Firefox is bugged not the app).  However, changes have been made to fix the issue.  The following was done to test the fix on Firefox, Chrome and Safari:
-click on experiment list page 
-set a filter (active, archived, etc)
-set a sort (name, status, etc)
After these steps are completed, the app should not crash anymore.