### PR TITLE
Sessions & Conversions Bugfix

### DIFF
--- a/app/components/ConversionsCard.jsx
+++ b/app/components/ConversionsCard.jsx
@@ -69,6 +69,11 @@ export default function ConversionsCard({ conversionsData, sessionData, hasExper
         }}>
           <div style={{ height: "250px", width: "100%" , minHeight: "250px", position: "relative"}}>
             {isClient ? (
+              chartData.length === 0 ? (
+                <div style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
+                  <s-text color="subdued">No conversion data to display yet.</s-text>
+                </div>
+              ) : (
               <ResponsiveContainer width="100%" height="100%" minWidth="0px">
                 <AreaChart data={chartData} debounce={50} margin={{ top: 10, right: 10, left: -20, bottom: 0 }}>
                   <defs>
@@ -121,6 +126,7 @@ export default function ConversionsCard({ conversionsData, sessionData, hasExper
                   />
                 </AreaChart>
               </ResponsiveContainer>
+              )
             ) : (
               <div style={{ textAlign: "center", paddingTop: "100px" }}>
                 <s-text tone="subdued">Loading chart data...</s-text>

--- a/app/components/SessionsCard.jsx
+++ b/app/components/SessionsCard.jsx
@@ -71,9 +71,16 @@ export default function SessionsCard({ sessionData }) {
                     axisLine={false} 
                     tickLine={false} 
                     tick={{ fill: '#8c9196', fontSize: 11 }}
+                    tickFormatter={(value) => {
+                      if (value > 1000) {
+                        return `${(value / 1000).toFixed(0)}k`;
+                      }
+                      return `${value}`;
+                    }}
                   />
                   
                   <Tooltip 
+                    formatter={(value) => [`${Number(value).toFixed(0)}`, "Sessions"]}
                     contentStyle={{ 
                       borderRadius: "8px", 
                       border: "1px solid #ebebeb", 

--- a/app/services/analytics.server.js
+++ b/app/services/analytics.server.js
@@ -19,6 +19,8 @@ export async function getSessionReportData(admin, start, end) {
           tableData {
             columns {
               name
+              dataType
+              displayName
             }
             rows
           }
@@ -27,12 +29,16 @@ export async function getSessionReportData(admin, start, end) {
       }`,
       {
         variables: {
-          query: `SHOW sessions SINCE ${startDate} UNTIL ${endDate} TIMESERIES day`,
+          query: `FROM sessions SHOW sessions SINCE ${startDate} UNTIL ${endDate} TIMESERIES day`,
         },
       },
     );
 
     const resJson = await response.json();
+
+    // Console logging 
+    //console.dir(resJson.data.shopifyqlQuery.parseErrors, { depth: null });
+    //console.dir(resJson.data.shopifyqlQuery.tableData, { depth: null });
 
     // Validate and Parse Shopify API Data
     // Check for GraphQL errors or ShopifyQL specific parse errors
@@ -46,12 +52,12 @@ export async function getSessionReportData(admin, start, end) {
 
     if (rows && rows.length > 0) {
       console.log(
-        `[analytics.server] Successfully fetched ${rows.length} live rows.`,
+        `[analytics.server] Successfully fetched ${rows.length} live session rows.`,
       );
 
       const sessions = rows.map((row) => ({
-        date: row[0], // ShopifyQL usually returns date as the first column
-        count: parseInt(row[1], 10), // and count as the second
+        date: row.day, // ShopifyQL usually returns date as the first column
+        count: parseInt(row.sessions, 10) || 0, // and count as the second
       }));
 
       return {
@@ -65,9 +71,9 @@ export async function getSessionReportData(admin, start, end) {
   } catch (error) {
     // If the API fails (Permissions, TableResponse error, etc.), use the mock generator.
     console.warn(
-      `[analytics.server] API Error or No Data. Falling back to mock: ${error.message}`,
+      `[analytics.server] API Error or No Data: ${error.message}`,
     );
-    return generateMockSessions(startDate, endDate);
+    return {sessions: [], total: 0};
   }
 }
 
@@ -142,7 +148,7 @@ export async function getConversionsReportData(admin, start, end) {
 
     if (rows && rows.length > 0) {
       console.log(
-        `[analytics.server] Successfully fetched ${rows.length} live rows.`,
+        `[analytics.server] Successfully fetched ${rows.length} live conversion rows.`,
       );
 
       const sessions = rows.map((row) => ({
@@ -161,8 +167,8 @@ export async function getConversionsReportData(admin, start, end) {
   } catch (error) {
     // If the API fails (Permissions, TableResponse error, etc.), use the mock generator.
     console.warn(
-      `[analytics.server] API Error or No Data. Falling back to mock: ${error.message}`,
+      `[analytics.server] Conversion API Error or No Data: ${error.message}`,
     );
-    return generateMockSessions(startDate, endDate);
+    return {sessions: [], total: 0};
   }
 }

--- a/app/services/conversions.server.js
+++ b/app/services/conversions.server.js
@@ -35,6 +35,10 @@ export async function getConversionsReportData(admin, start, end) {
     );
 
     const resJson = await response.json();
+    
+    // Console logging
+    // console.dir(resJson.data.shopifyqlQuery.parseErrors, { depth: null });
+    // console.dir(resJson.data.shopifyqlQuery.tableData, { depth: null });
 
     // Validate and Parse Shopify API Data
     // Check for GraphQL errors or ShopifyQL specific parse errors
@@ -46,37 +50,23 @@ export async function getConversionsReportData(admin, start, end) {
 
     const tableData = resJson.data?.shopifyqlQuery?.tableData;
     const rows = tableData?.rows;
-    const columns = tableData?.columns || [];
 
     if (rows && rows.length > 0) {
       console.log(
         `[conversions.server] Successfully fetched ${rows.length} live rows.`,
       );
 
-      const indexByName = new Map(
-        columns.map((col, index) => [String(col.name || "").toLowerCase(), index]),
-      );
-
-      const pick = (row, key, fallbackIndex) => {
-        const idx = indexByName.get(key);
-        const value = row[idx ?? fallbackIndex];
-        return Number(value) || 0;
-      };
-
       const sessions = rows.map((row) => {
-        const totalSessions = pick(row, "sessions", 1);
-        const addedToCart = pick(row, "sessions_with_cart_additions", 2);
-        const reachedCheckout = pick(row, "sessions_that_reached_checkout", 3);
-        const completedCheckout = pick(row, "sessions_that_completed_checkout", 4);
-        const apiRate = Number(row[indexByName.get("conversion_rate") ?? 5]);
-        const conversionRate = Number.isFinite(apiRate)
-          ? apiRate
-          : totalSessions > 0
-            ? (completedCheckout / totalSessions) * 100
-            : 0;
+        const totalSessions = Number(row.sessions) || 0;
+        const addedToCart = Number(row.sessions_with_cart_additions) || 0;
+        const reachedCheckout = Number(row.sessions_that_reached_checkout) || 0;
+        const completedCheckout = Number(row.sessions_that_completed_checkout) || 0;
+        const apiRate = Number(row.conversion_rate) || 0;
+
+        const conversionRate = apiRate > 0 ? apiRate : totalSessions > 0 ? (completedCheckout / totalSessions) * 100 : 0;
 
         return {
-          date: row[0],
+          date: row.day,
           // `count` remains the charted conversion count for compatibility.
           count: completedCheckout,
           sessions: totalSessions,


### PR DESCRIPTION
Solves ET-622. To test, you will have to Create an Experiment, complete with a section ID selected using the Visually Select button, and do a walkthrough of: 

1. Visiting your dev store (on a browser you don't use, like Edge/Chrome/Firefox to make sure you don't have any adblocker enabled) 
2. Clicking on a product 
3. Add to cart 
4. Proceed to checkout 
5. And buy the item

Note: It looks like Shopify drops storefront session data if the browser is associated with an active Shopify admin login, so if all else fails, try to visit the site (sessions) and check out (conversions) on your mobile device using your mobile data for simulated testing data.

- Both rechart components in the Reports index page now display live Sessions & Conversions metrics

- Sessions card now accounts for sessions in the thousands and truncates accordingly for a better UX

- Conversions card now displays a "No conversion data to display yet" text when there is no data to display

<img width="707" height="667" alt="image" src="https://github.com/user-attachments/assets/a8c88f0a-a9d6-4070-9cfe-4ee6b3cada5b" />

<img width="511" height="686" alt="image" src="https://github.com/user-attachments/assets/6f769596-396d-4be2-b522-6822fffa5092" />
