### PR TITLE
extension.server web pixel refresh

### DIFF
--- a/app/__tests__/extension.server.test.js
+++ b/app/__tests__/extension.server.test.js
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  graphql: vi.fn(),
+  findUnique: vi.fn(),
+  update: vi.fn(),
+}));
+
+vi.mock("../db.server", () => ({
+  default: {
+    session: {
+      findUnique: mocks.findUnique,
+      update: mocks.update,
+    },
+  },
+}));
+
+vi.mock("../shopify.server", () => ({
+  authenticate: {
+    admin: vi.fn(),
+  },
+}));
+
+import { updateWebPixel, registerWebPixel } from "../services/extension.server.js";
+import { authenticate } from "../shopify.server";
+
+describe("extension.server.js web pixel", () => {
+  const session = { id: "session-1", shop: "test.myshopify.com" };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SHOPIFY_APP_URL = "https://ab-insightful.fly.dev";
+    authenticate.admin.mockResolvedValue({
+      admin: { graphql: mocks.graphql },
+      session,
+    });
+  });
+
+  it("updateWebPixel recovers from NOT_FOUND by fetching Shopify id and retries update", async () => {
+    let webPixelIdInDb = "gid://shopify/WebPixel/stale";
+    mocks.findUnique.mockImplementation(() =>
+      Promise.resolve({ id: session.id, webPixelId: webPixelIdInDb }),
+    );
+    mocks.update.mockImplementation(async ({ data }) => {
+      if ("webPixelId" in data) webPixelIdInDb = data.webPixelId;
+      return {};
+    });
+
+    const responses = [
+      {
+        data: {
+          webPixelUpdate: {
+            userErrors: [
+              {
+                code: "NOT_FOUND",
+                field: ["id"],
+                message:
+                  "The web pixel with the ID used as the input value couldn't be found.",
+              },
+            ],
+          },
+        },
+      },
+      {
+        data: {
+          webPixel: {
+            id: "gid://shopify/WebPixel/fresh",
+            settings: {},
+          },
+        },
+      },
+      {
+        data: {
+          webPixelUpdate: {
+            userErrors: [],
+            webPixel: {
+              id: "gid://shopify/WebPixel/fresh",
+              settings: { appUrl: "https://ab-insightful.fly.dev" },
+            },
+          },
+        },
+      },
+    ];
+    let i = 0;
+    mocks.graphql.mockImplementation(async () => ({
+      json: async () => responses[i++],
+    }));
+
+    const res = await updateWebPixel({ request: {} });
+    expect(res.status).toBe(200);
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: session.id },
+        data: { webPixelId: null },
+      }),
+    );
+    expect(mocks.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: session.id },
+        data: { webPixelId: "gid://shopify/WebPixel/fresh" },
+      }),
+    );
+    expect(mocks.graphql).toHaveBeenCalledTimes(3);
+  });
+
+  it("updateWebPixel recovers from NOT_FOUND via registerWebPixel when Shopify has no pixel", async () => {
+    let webPixelIdInDb = "gid://shopify/WebPixel/stale";
+    mocks.findUnique.mockImplementation(() =>
+      Promise.resolve({ id: session.id, webPixelId: webPixelIdInDb }),
+    );
+    mocks.update.mockImplementation(async ({ data }) => {
+      if ("webPixelId" in data) webPixelIdInDb = data.webPixelId;
+      return {};
+    });
+
+    const responses = [
+      {
+        data: {
+          webPixelUpdate: {
+            userErrors: [{ code: "NOT_FOUND", field: ["id"], message: "missing" }],
+          },
+        },
+      },
+      { data: { webPixel: null } },
+      {
+        data: {
+          webPixelCreate: {
+            userErrors: [],
+            webPixel: {
+              id: "gid://shopify/WebPixel/created",
+              settings: {},
+            },
+          },
+        },
+      },
+      {
+        data: {
+          webPixelUpdate: {
+            userErrors: [],
+            webPixel: {
+              id: "gid://shopify/WebPixel/created",
+              settings: { appUrl: "https://ab-insightful.fly.dev" },
+            },
+          },
+        },
+      },
+    ];
+    let i = 0;
+    mocks.graphql.mockImplementation(async () => ({
+      json: async () => responses[i++],
+    }));
+
+    const res = await updateWebPixel({ request: {} });
+    expect(res.status).toBe(200);
+    expect(mocks.graphql).toHaveBeenCalledTimes(4);
+  });
+
+  it("registerWebPixel replaces stale DB id when Shopify returns a different id", async () => {
+    mocks.findUnique.mockResolvedValue({
+      id: session.id,
+      webPixelId: "gid://shopify/WebPixel/stale",
+    });
+    mocks.update.mockResolvedValue({});
+
+    mocks.graphql.mockImplementation(async () => ({
+      json: async () => ({
+        data: {
+          webPixel: {
+            id: "gid://shopify/WebPixel/canonical",
+            settings: {},
+          },
+        },
+      }),
+    }));
+
+    const res = await registerWebPixel({ request: {} });
+    expect(res.status).toBe(200);
+    expect(mocks.update).toHaveBeenCalledWith({
+      where: { id: session.id },
+      data: { webPixelId: "gid://shopify/WebPixel/canonical" },
+    });
+    expect(mocks.graphql).toHaveBeenCalledTimes(1);
+  });
+
+  it("registerWebPixel clears stale id and creates when Shopify has no pixel", async () => {
+    let webPixelIdInDb = "gid://shopify/WebPixel/ghost";
+    mocks.findUnique.mockImplementation(() =>
+      Promise.resolve({ id: session.id, webPixelId: webPixelIdInDb }),
+    );
+    mocks.update.mockImplementation(async ({ data }) => {
+      if ("webPixelId" in data) webPixelIdInDb = data.webPixelId;
+      return {};
+    });
+
+    const responses = [
+      { data: { webPixel: null } },
+      {
+        data: {
+          webPixelCreate: {
+            userErrors: [],
+            webPixel: {
+              id: "gid://shopify/WebPixel/new",
+              settings: {},
+            },
+          },
+        },
+      },
+    ];
+    let i = 0;
+    mocks.graphql.mockImplementation(async () => ({
+      json: async () => responses[i++],
+    }));
+
+    const res = await registerWebPixel({ request: {} });
+    expect(res.status).toBe(200);
+    expect(mocks.update).toHaveBeenCalledWith({
+      where: { id: session.id },
+      data: { webPixelId: null },
+    });
+    expect(mocks.update).toHaveBeenCalledWith({
+      where: { id: session.id },
+      data: { webPixelId: "gid://shopify/WebPixel/new" },
+    });
+  });
+});

--- a/app/services/extension.server.js
+++ b/app/services/extension.server.js
@@ -6,17 +6,33 @@ export async function registerWebPixel({ request }) {
   const { admin, session } = await authenticate.admin(request);
 
   // First check to see if the web pixel is already registered
-  const webPixelId = await getWebPixelId(session);
+  let webPixelId = await getWebPixelId(session);
 
   if (webPixelId) {
-    return new Response(
-      JSON.stringify({
-        message:
-          "App pixel registered successfully. You can mark this step as complete!",
-        action: "enableTracking",
-      }),
-      { status: 200 },
-    );
+    const shopifyId = await fetchWebPixelIdFromShopify(admin);
+    if (shopifyId === webPixelId) {
+      return new Response(
+        JSON.stringify({
+          message:
+            "App pixel registered successfully. You can mark this step as complete!",
+          action: "enableTracking",
+        }),
+        { status: 200 },
+      );
+    }
+    if (shopifyId) {
+      await storeWebPixelId(session, shopifyId);
+      return new Response(
+        JSON.stringify({
+          message:
+            "App pixel registered successfully. You can mark this step as complete!",
+          action: "enableTracking",
+        }),
+        { status: 200 },
+      );
+    }
+    await clearWebPixelId(session);
+    webPixelId = null;
   }
 
   const settings = {
@@ -130,8 +146,99 @@ export async function updateWebPixel({ request }) {
     appUrl: process.env.SHOPIFY_APP_URL,
   };
 
-  console.log(`Updating web pixel ${webPixelId} with appUrl: ${settings.appUrl}`);
+  let recoveredFromNotFound = false;
 
+  for (;;) {
+    console.log(`Updating web pixel ${webPixelId} with appUrl: ${settings.appUrl}`);
+
+    const responseAsJSON = await performWebPixelUpdate(
+      admin,
+      webPixelId,
+      settings,
+    );
+    const userErrors = responseAsJSON.data?.webPixelUpdate?.userErrors ?? [];
+    const notFound = userErrors.some((e) => e.code === "NOT_FOUND");
+
+    if (notFound && !recoveredFromNotFound) {
+      recoveredFromNotFound = true;
+      console.log(
+        "Web pixel ID not found on Shopify; clearing stale ID and re-resolving...",
+      );
+      await clearWebPixelId(session);
+      const fromShopify = await fetchWebPixelIdFromShopify(admin);
+      if (fromShopify) {
+        await storeWebPixelId(session, fromShopify);
+        webPixelId = fromShopify;
+        continue;
+      }
+      await registerWebPixel({ request });
+      webPixelId = await getWebPixelId(session);
+      if (!webPixelId) {
+        console.error("Unable to obtain web pixel ID after NOT_FOUND recovery.");
+        return new Response(
+          JSON.stringify({
+            message:
+              "App pixel could not be updated — unable to find or create the web pixel. Try deleting ab-insightful from Shopify Admin -> Settings -> Customer events and re-registering.",
+            action: "updateWebPixel",
+          }),
+          { status: 500 },
+        );
+      }
+      continue;
+    }
+
+    if (userErrors.length > 0) {
+      console.error(
+        "An error occurred while trying to update the Web Pixel App Extension:",
+        userErrors,
+      );
+      return new Response(
+        JSON.stringify({
+          message: "App pixel was unable to update.",
+          action: "updateWebPixel",
+        }),
+        { status: 500 },
+      );
+    }
+
+    const newWebPixelSettings =
+      responseAsJSON.data?.webPixelUpdate?.webPixel?.settings;
+    console.log(`Web pixel updated. New settings: ${newWebPixelSettings}`);
+    return new Response(
+      JSON.stringify({
+        message: "App pixel updated successfully.",
+        action: "updateWebPixel",
+      }),
+      { status: 200 },
+    );
+  }
+}
+
+// Function for getting Web Pixel ID from database
+async function getWebPixelId(session) {
+  const currentSession = await db.session.findUnique({
+    where: {
+      id: session.id,
+    },
+  });
+  return currentSession?.webPixelId ?? null;
+}
+
+async function storeWebPixelId(session, webPixelId) {
+  await db.session.update({
+    where: { id: session.id },
+    data: { webPixelId },
+  });
+}
+
+async function clearWebPixelId(session) {
+  await db.session.update({
+    where: { id: session.id },
+    data: { webPixelId: null },
+  });
+}
+
+async function performWebPixelUpdate(admin, webPixelId, settings) {
   const response = await admin.graphql(
     `#graphql
         mutation($id: ID!, $settings: JSON!) {
@@ -155,49 +262,7 @@ export async function updateWebPixel({ request }) {
       },
     },
   );
-
-  const responseAsJSON = await response.json();
-  if (responseAsJSON.data?.webPixelUpdate?.userErrors?.length > 0) {
-    console.error(
-      "An error occurred while trying to update the Web Pixel App Extension:",
-      responseAsJSON.data.webPixelUpdate.userErrors,
-    );
-    return new Response(
-      JSON.stringify({
-        message: "App pixel was unable to update.",
-        action: "updateWebPixel",
-      }),
-      { status: 500 },
-    );
-  }
-
-  const newWebPixelSettings =
-    responseAsJSON.data?.webPixelUpdate?.webPixel?.settings;
-  console.log(`Web pixel updated. New settings: ${newWebPixelSettings}`);
-  return new Response(
-    JSON.stringify({
-      message: "App pixel updated successfully.",
-      action: "updateWebPixel",
-    }),
-    { status: 200 },
-  );
-}
-
-// Function for getting Web Pixel ID from database
-async function getWebPixelId(session) {
-  const currentSession = await db.session.findUnique({
-    where: {
-      id: session.id,
-    },
-  });
-  return currentSession?.webPixelId ?? null;
-}
-
-async function storeWebPixelId(session, webPixelId) {
-  await db.session.update({
-    where: { id: session.id },
-    data: { webPixelId },
-  });
+  return response.json();
 }
 
 // Query Shopify for the existing web pixel (works without an ID since API 2023-04)


### PR DESCRIPTION
- our web pixel id is now coupled with the GID on Shopify's end

- if these two dont match when looking up the web pixel ID, the stale ID is thrown out and a new one is generated and paired, so to speak

Note: The VM will auto shut off if a successful cron job doesnt execute within 5 minutes iirc. Be patient and prepared to start the VM again. 

Install Fly io 
[Install flyctl](https://fly.io/docs/flyctl/install/) 

Switch shopify app toml used with

`shopify app config use`

Select
`shopify.app.prod.toml`

Now, uninstall AB Insightful in your admin dashboard. 

Access the app through the admin page: (sign in to your store)
https://www.shopify.com/store-login  

Locate the apps tab, and select app settings and uninstall ab-insightful

Go back to your terminal, and authenticate with Fly io, you'll need the Fly credentials here. Ask Tosh, Ben, Ryan, Emmanuel, or Paul for creds. 

`flyctl auth login`

Follow the steps outlined here to finish authenticating. 

Now, start the VM on fly io. This can be found in the apps dashboard on fly io . Again, you'll need Tosh's credentials to log in. 

Locate Ab-Insightful (the none, revRides one, the correct one should be listed first) 

Under Machines, turn on the VM named.

82973dc7734ee8 cold-dew-3153

Press the terminal icon to view the VMs console logs and see the app boot up. 

At this point, you'll have to reinstall the app. Follow this link,

https://admin.shopify.com/oauth/install_custom_app?client_id=656b84090c3d90435a1675270b9182d8&no_redirect=true&signature=eyJleHBpcmVzX2F0IjoxNzYxMjE0MDEyLCJwZXJtYW5lbnRfZG9tYWluIjoibWlzYWR2ZW50dXJlLXRpbWUubXlzaG9waWZ5LmNvbSIsImNsaWVudF9pZCI6IjY1NmI4NDA5MGMzZDkwNDM1YTE2NzUyNzBiOTE4MmQ4IiwicHVycG9zZSI6ImN1c3RvbV9hcHAiLCJtZXJjaGFudF9vcmdhbml6YXRpb25faWQiOjE2OTkyODM3M30%3D--bb40851377d6aacacdd03e5408c1220ad0ef53d9 

You can now access Ab Insightful on your dev store admin dashboard.

Functionally test the new Web Pixel Id refresh by moving around through the app, namely, the Reports page and Experiments page. 

To functioanlly test a stale web pixel Id (ie the error in the past), you'll have to ssh into the VM through your terminal. 

`fly ssh console -a ab-insightful`

Then, you can run the following to insert a stale GID web pixel id.

npx prisma db execute --url "file:/app/prisma/dev.sqlite" --stdin <<'EOF' UPDATE Session SET webPixelId = 'gid://shopify/WebPixel/stale-test-id' WHERE shop = 'your-shop-name.myshopify.com'; EOF

After seeing the script executed successfully, go back to the app in your browser, and move back in forth between the Reports page and Experiments page.

Look at the VM logs on fly io , and notice that
<img width="792" height="320" alt="image" src="https://github.com/user-attachments/assets/27181c2e-ae0b-43b1-8147-94e6785e80bf" />

We dont get that error stemming from a stale GID. 