### PR TITLE
ET-662 - Fixed malform query, added aggregation functionality

### DIFF
--- a/app/__tests__/experiment.server.test.jsx
+++ b/app/__tests__/experiment.server.test.jsx
@@ -393,14 +393,14 @@ describe("experimentListReport", () => {
     expect(arg.select.analyses).toBeDefined();
     expect(arg.orderBy).toEqual({ createdAt: "desc" });
     expect(result).toEqual(mockExperiments);
-  });
+  }) ?? [];
 
   test("returns null when no experiments found", async () => {
-    db.experiment.findMany.mockResolvedValueOnce(null);
+    db.experiment.findMany.mockResolvedValueOnce([]); //pretends to return [] on db query
 
     const result = await experimentListReport();
 
-    expect(result).toBeNull();
+    expect(result).toEqual([]);
   });
 
   test("returns empty array when experiments is empty", async () => {

--- a/app/routes/app.reports.$id.jsx
+++ b/app/routes/app.reports.$id.jsx
@@ -179,7 +179,7 @@ export async function loader({ params, request }) {
 export default function Report() {
   // Load report information
   const { experiment, analysis, deviceSegment } = useLoaderData();
-  const safeAnalysis = (analysis ?? []).filter(Boolean);
+  const safeAnalysis = (analysis ?? []).filter(Boolean); //based off safeAnalysis
 
   //status manager refresher
   const fetcher = useFetcher();

--- a/app/routes/app.reports._index.jsx
+++ b/app/routes/app.reports._index.jsx
@@ -222,6 +222,7 @@ export default function Reports() {
   //get conversions for experiment
   const getConversionRate = (experiment) => {
     //check for analysis data
+    //aggregate information
     if (experiment.analyses && experiment.analyses.length > 0) {
       //get the most recent analysis
       let summedUsers = 0;
@@ -232,9 +233,6 @@ export default function Reports() {
         summedUsers += totalUsers;
         summedConversions += totalConversions;
       }
-      
-      
-      //get the conversions and users from analysis
 
       //check for valid data
       if (
@@ -246,7 +244,7 @@ export default function Reports() {
         return `${summedConversions}/${summedUsers}`;
       }
     }
-    return "N/A";
+    return "N/A"; //no experiment data
   };
 
   //function responsible for render of table rows based off db

--- a/app/routes/app.reports._index.jsx
+++ b/app/routes/app.reports._index.jsx
@@ -34,7 +34,6 @@ export async function loader({ request }) {
     getSessionReportData(admin),
     getConversionsReportData(admin),
   ]);
-
   //looks up tutorial data
   const { getTutorialData } = await import("../services/tutorialData.server");
   const tutorialInfo = await getTutorialData();
@@ -225,19 +224,26 @@ export default function Reports() {
     //check for analysis data
     if (experiment.analyses && experiment.analyses.length > 0) {
       //get the most recent analysis
-      const latestAnalysis =
-        experiment.analyses[experiment.analyses.length - 1];
+      let summedUsers = 0;
+      let summedConversions = 0; 
+      for (let i = 0; i < experiment.analyses.length; i++) { 
+        let latestAnalysis = experiment.analyses[i];
+        let {totalConversions, totalUsers} = latestAnalysis;
+        summedUsers += totalUsers;
+        summedConversions += totalConversions;
+      }
+      
+      
       //get the conversions and users from analysis
-      const { totalConversions, totalUsers } = latestAnalysis;
 
       //check for valid data
       if (
-        totalConversions !== null &&
-        totalConversions !== undefined &&
-        totalUsers !== null &&
-        totalUsers !== undefined
+        summedConversions !== null &&
+        summedConversions !== undefined &&
+        summedUsers !== null &&
+        summedUsers !== undefined
       ) {
-        return `${totalConversions}/${totalUsers}`;
+        return `${summedConversions}/${summedUsers}`;
       }
     }
     return "N/A";

--- a/app/services/experiment.server.js
+++ b/app/services/experiment.server.js
@@ -254,7 +254,7 @@ export async function getExperimentsList() {
 //NOTE:currently scoped to live in the app.reports_index page, which means it is not scoped
 //to perform device filters elsewhere without some kind of action based update functionality.  
 export async function experimentListReport(filterDevSeg = "all") {
-  const experiments = await db.experiment.findMany({
+  const experiments = (await db.experiment.findMany({
     select: {
       id: true,
       name: true,
@@ -292,10 +292,10 @@ export async function experimentListReport(filterDevSeg = "all") {
     orderBy: {
       createdAt: "desc",
     },
-  });
+  })) ?? []; //returns empty array if null
 
   //returns the mapped version of the experiment with only latest analyses.
-  //will returns empty array if nothing is found. 
+  //will returns empty array if nothing is found.
   return experiments.map(function (experiment) {
     var latestCalculatedWhen = null;
 
@@ -305,7 +305,7 @@ export async function experimentListReport(filterDevSeg = "all") {
     }
 
     var latestAnalyses = [];
-
+    if (!experiments) return [];
     //function returns all the valid analysis that match given time. 
     if (latestCalculatedWhen) {
       latestAnalyses = experiment.analyses.filter(function (analysis) {

--- a/app/services/experiment.server.js
+++ b/app/services/experiment.server.js
@@ -250,13 +250,16 @@ export async function getExperimentsList() {
   return experiments; // Returns an array of experiments,
 }
 
-//get the experiment list, additionally analyses for conversion rate
-export async function experimentListReport() {
+//get the experiment list as well as additional analyses for conversion rate
+//NOTE:currently scoped to live in the app.reports_index page, which means it is not scoped
+//to perform device filters elsewhere without some kind of action based update functionality.  
+export async function experimentListReport(filterDevSeg = "all") {
   const experiments = await db.experiment.findMany({
     select: {
       id: true,
       name: true,
       status: true,
+      variants: true,
       startDate: true,
       endDate: true,
       endCondition: true,
@@ -278,8 +281,11 @@ export async function experimentListReport() {
           totalUsers: true,
           calculatedWhen: true,
         },
+        where: { 
+          deviceSegment:filterDevSeg, 
+        },
         orderBy: {
-          calculatedWhen: "asc",
+          calculatedWhen: "desc",
         },
       },
     },
@@ -288,8 +294,36 @@ export async function experimentListReport() {
     },
   });
 
-  if (experiments) return experiments;
-  else return null;
+  //returns the mapped version of the experiment with only latest analyses.
+  //will returns empty array if nothing is found. 
+  return experiments.map(function (experiment) {
+    var latestCalculatedWhen = null;
+
+    //instantiates variable for future comparison based off of time
+    if (experiment.analyses.length > 0) {
+      latestCalculatedWhen = experiment.analyses[0].calculatedWhen;
+    }
+
+    var latestAnalyses = [];
+
+    //function returns all the valid analysis that match given time. 
+    if (latestCalculatedWhen) {
+      latestAnalyses = experiment.analyses.filter(function (analysis) {
+        return analysis.calculatedWhen.getTime() === latestCalculatedWhen.getTime();
+      });
+    }
+
+    return {
+      id: experiment.id,
+      name: experiment.name,
+      status: experiment.status,
+      startDate: experiment.startDate,
+      endDate: experiment.endDate,
+      endCondition: experiment.endCondition,
+      history: experiment.history,
+      analyses: latestAnalyses,
+    };
+  });
 }
 
 // get a variant (by name or id) Example: "Control" or "Variant A"


### PR DESCRIPTION
Fixed bug of incorrect conversion rates bug. Now renders the sum of all conversions/visitors for a given experiment. For validation, you should see that for general reporting the conversions table data will be the sum of all of the variant conversion rate data. Pictures attached for reference. 
<img width="824" height="328" alt="individualReports" src="https://github.com/user-attachments/assets/5f968a85-7106-4859-9652-31914d7867cb" />
<img width="1274" height="475" alt="generalReports" src="https://github.com/user-attachments/assets/051e19ee-cc69-41ec-b58c-f686f17125c9" />

