### PR TITLE
added bare minimum prod seed

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,8 @@
     "seed:dev": "node prisma/seed.js --environment=dev",
     "seed:test": "node prisma/seed.js --environment=test",
     "seed:demo": "node prisma/seed.js --environment=demo",
+    "seed:base": "node prisma/seed.js --environment=base",
+    "seed:prod": "node prisma/seed.js --environment=prod",
     "db:dev": "node scripts/switch-db.js --environment=dev",
     "db:test": "node scripts/switch-db.js --environment=test",
     "db:prod": "node scripts/switch-db.js --environment=prod",
@@ -39,7 +41,9 @@
   "prisma": {
     "seed:dev": "node prisma/seed.js --environment=dev",
     "seed:test": "node prisma/seed.js --environment=test",
-    "seed:demo": "node prisma/seed.js --environment=demo"
+    "seed:demo": "node prisma/seed.js --environment=demo",
+    "seed:base": "node prisma/seed.js --environment=base",
+    "seed:prod": "node prisma/seed.js --environment=prod"
   },
   "type": "module",
   "engines": {

--- a/prisma/seed.js
+++ b/prisma/seed.js
@@ -5,6 +5,8 @@ import { PrismaClient } from '@prisma/client'
 import { seedDev } from './seed.dev.js'
 import { seedTest } from './seed.test.js'
 import { seedDemo } from './seed.demo.js'
+import { seedBase } from './seed.base.js'
+import { seedProd } from './seed.prod.js'
 
 const options = { // define the options your script supports
   environment: { type: 'string' },
@@ -19,6 +21,12 @@ async function main() {
 
   switch (environment) { // add a case for each environment you want to support.
 
+    case 'base':
+      await seedBase(prisma);
+      break;
+    case 'prod':
+      await seedProd(prisma);
+      break;
     case 'dev':
       /** data for your development */
       await seedDev(prisma);
@@ -30,7 +38,7 @@ async function main() {
       await seedDemo(prisma);
       break;
     default:
-      throw new error("Invalid environment. Use --environment=dev|test|demo");
+      throw new Error("Invalid environment. Use --environment=dev|test|demo");
   }
 }
 

--- a/prisma/seed.prod.js
+++ b/prisma/seed.prod.js
@@ -1,0 +1,91 @@
+export async function seedProd(prisma) {
+  const project = await prisma.project.upsert({
+    where: { shop: "dev-example.myshopify.com" },
+    update: {
+      name: "Default Project",
+      maxUsersPerExperiment: 10000,
+    },
+    create: {
+      shop: "dev-example.myshopify.com",
+      name: "Default Project",
+      maxUsersPerExperiment: 10000,
+    },
+  });
+
+  const session = await prisma.session.upsert({
+    where: { id: "prod-seed-session" },
+    update: {
+      shop: project.shop,
+    },
+    create: {
+      id: "prod-seed-session",
+      shop: project.shop,
+      state: "seed",
+      accessToken: "seed-token",
+      isOnline: true,
+    },
+  });
+
+  await prisma.goal.upsert({
+    where: { name: "Completed Checkout" },
+    update: {},
+    create: {
+      name: "Completed Checkout",
+      metricType: "revenue",
+      icon: "shopping_cart",
+    },
+  });
+
+  await prisma.goal.upsert({
+    where: { name: "Started Checkout" },
+    update: {},
+    create: {
+      name: "Started Checkout",
+      metricType: "conversion",
+      icon: "checkout",
+    },
+  });
+
+  await prisma.goal.upsert({
+    where: { name: "Viewed Page" },
+    update: {},
+    create: {
+      name: "Viewed Page",
+      metricType: "conversion",
+      icon: "visibility",
+    },
+  });
+
+  await prisma.goal.upsert({
+    where: { name: "Added Product To Cart" },
+    update: {},
+    create: {
+      name: "Added Product To Cart",
+      metricType: "conversion",
+      icon: "add_shopping_cart",
+    },
+  });
+
+  await prisma.tutorialData.upsert({
+    where: { id: 1 },
+    update: {
+      sessionId: session.id,
+      generalSettings: false,
+      createExperiment: false,
+      viewedListExperiment: false,
+      viewedReportsPage: false,
+      onSiteTracking: false,
+    },
+    create: {
+      id: 1,
+      sessionId: session.id,
+      generalSettings: false,
+      createExperiment: false,
+      viewedListExperiment: false,
+      viewedReportsPage: false,
+      onSiteTracking: false,
+    },
+  });
+
+  console.log('Prod seed completed successfully.');
+}


### PR DESCRIPTION
Adds a minimal prod seed for deployment so we have a safe seed path that doesn’t insert a bunch of dev/demo data into production. This keeps prod seeding separate from the other environments and makes the deployment seed bare minimum on purpose.

Commands added
- `npm run seed:prod`  This will seed the current targeted DB with the bare minimum prod seed
- `npm run seed:base`  This will seed the current targeted DB with the Base seed, has bare bones seeding data