### PR TITLE
Fix empty-state rendering for dashboard charts

### DIFF
--- a/app/__tests__/ConversionsCard.test.jsx
+++ b/app/__tests__/ConversionsCard.test.jsx
@@ -61,6 +61,33 @@ describe("ConversionsCard", () => {
     expect(screen.getByText("0.00%")).toBeInTheDocument();
   });
 
+  it("shows the no-data state when all merged conversion points resolve to zero", async () => {
+    render(
+      <ConversionsCard
+        conversionsData={{
+          sessions: [
+            { date: "2026-01-01", count: 0 },
+            { date: "2026-01-02", count: 5 },
+          ],
+        }}
+        sessionData={{
+          sessions: [
+            { date: "2026-01-01", count: 0 },
+            { date: "2026-01-02", count: 0 },
+          ],
+        }}
+        hasExperiments
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("No conversion data to display yet.")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("area-chart")).not.toBeInTheDocument();
+    expect(screen.getByText("0.00%")).toBeInTheDocument();
+  });
+
   it("renders chart and computes conversion rates with sorted merged dates", async () => {
     render(
       <ConversionsCard

--- a/app/__tests__/SessionsCard.test.jsx
+++ b/app/__tests__/SessionsCard.test.jsx
@@ -1,0 +1,99 @@
+import React from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { renderToString } from "react-dom/server";
+
+vi.mock("recharts", () => ({
+  ResponsiveContainer: ({ children }) => <div data-testid="responsive-container">{children}</div>,
+  AreaChart: ({ data, children }) => (
+    <div data-testid="area-chart" data-chart={JSON.stringify(data)}>
+      {children}
+    </div>
+  ),
+  Area: () => <div data-testid="area" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  XAxis: ({ tickFormatter }) => <div data-testid="x-axis">{tickFormatter?.("2026-01-02T12:00:00Z")}</div>,
+  YAxis: ({ tickFormatter }) => <div data-testid="y-axis">{tickFormatter?.(1234)}</div>,
+  Tooltip: ({ formatter }) => {
+    const formatted = formatter?.(1234.56);
+    return <div data-testid="tooltip">{Array.isArray(formatted) ? formatted[0] : ""}</div>;
+  },
+}));
+
+import SessionsCard from "../components/SessionsCard";
+
+describe("SessionsCard", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders loading state before client hydration", () => {
+    const html = renderToString(<SessionsCard sessionData={{ sessions: [], total: 0 }} />);
+    expect(html).toContain("Loading chart data...");
+  });
+
+  it("shows no-data state when chart data is empty", async () => {
+    render(<SessionsCard sessionData={{ sessions: [], total: 0 }} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No session data to display yet.")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("0")).toBeInTheDocument();
+  });
+
+  it("shows no-data state when all session points are zero", async () => {
+    render(
+      <SessionsCard
+        sessionData={{
+          total: 0,
+          sessions: [
+            { date: "2026-01-01", count: 0 },
+            { date: "2026-01-02", count: 0 },
+          ],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("No session data to display yet.")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId("area-chart")).not.toBeInTheDocument();
+  });
+
+  it("renders chart when at least one session point is non-zero", async () => {
+    render(
+      <SessionsCard
+        sessionData={{
+          total: 1450,
+          sessions: [
+            { date: "2026-01-01", count: 0 },
+            { date: "2026-01-02", count: 1450 },
+          ],
+        }}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("area-chart")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("1,450")).toBeInTheDocument();
+    expect(screen.getByTestId("x-axis")).toHaveTextContent("Jan");
+    expect(screen.getByTestId("y-axis")).toHaveTextContent("1k");
+    expect(screen.getByTestId("tooltip")).toHaveTextContent("1235");
+  });
+
+  it("opens Shopify full report URL in top frame", () => {
+    const openSpy = vi.spyOn(window, "open").mockImplementation(() => null);
+    render(<SessionsCard sessionData={{ sessions: [], total: 0 }} />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Full Report" }));
+
+    expect(openSpy).toHaveBeenCalledWith(
+      "shopify://admin/analytics/reports/sessions_over_time",
+      "_top",
+    );
+  });
+});

--- a/app/__tests__/app._index.test.jsx
+++ b/app/__tests__/app._index.test.jsx
@@ -3,6 +3,21 @@ import { vi, describe, it, expect } from 'vitest';
 import { useLoaderData, useFetcher } from 'react-router';
 import Index from '../routes/app._index'; 
 
+vi.mock('recharts', () => ({
+  LineChart: ({ children }) => <div data-testid="line-chart">{children}</div>,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  ResponsiveContainer: ({ children }) => <div data-testid="responsive-container">{children}</div>,
+}));
+
+vi.mock('../components/DateRangePicker', () => ({
+  default: () => <div>DateRangePicker</div>,
+}));
+
 // Mock the specific hooks
 vi.mock('react-router', () => ({
   useLoaderData: vi.fn(),
@@ -67,6 +82,68 @@ describe('Index Component - Happy Path', () => {
     // Verify Formatter Integration
     expect(screen.getByText('50/1000')).toBeInTheDocument(); 
     expect(screen.getByText('45.0%')).toBeInTheDocument(); 
+  });
+
+  it('shows a no-data indicator instead of a graph when no chartable analysis data exists', async () => {
+    useLoaderData.mockReturnValue({
+      experiment: {
+        name: 'Main A/B Test',
+        variants: [{ id: 1, name: 'Original' }],
+        status: 'Active',
+        createdAt: '2026-01-01T12:00:00Z',
+        analyses: [],
+        experimentGoal: 'Purchase',
+      },
+      tableData: [],
+      tutorialData: { allSetupDone: true, webPixelStatus: true, onSiteTracking: true },
+      shop: 'demo-shop',
+    });
+
+    render(<Index />);
+
+    expect(await screen.findByText('No graph data available for the selected date range.')).toBeInTheDocument();
+    expect(screen.queryByTestId('line-chart')).not.toBeInTheDocument();
+  });
+
+  it('shows a no-data indicator when analyses only contain zero-metric rows', async () => {
+    useLoaderData.mockReturnValue({
+      experiment: {
+        name: 'Main A/B Test',
+        variants: [
+          { id: 1, name: 'Original' },
+          { id: 2, name: 'Variant A' },
+        ],
+        status: 'Active',
+        createdAt: '2026-01-01T12:00:00Z',
+        analyses: [
+          {
+            calculatedWhen: '2026-01-05T00:00:00Z',
+            totalConversions: 0,
+            totalUsers: 300,
+            probabilityOfBeingBest: 0,
+            expectedLoss: 0,
+            variant: { name: 'Original' },
+          },
+          {
+            calculatedWhen: '2026-01-05T00:00:00Z',
+            totalConversions: 12,
+            totalUsers: 0,
+            probabilityOfBeingBest: 0,
+            expectedLoss: 0,
+            variant: { name: 'Variant A' },
+          },
+        ],
+        experimentGoal: 'Purchase',
+      },
+      tableData: [],
+      tutorialData: { allSetupDone: true, webPixelStatus: true, onSiteTracking: true },
+      shop: 'demo-shop',
+    });
+
+    render(<Index />);
+
+    expect(await screen.findByText('No graph data available for the selected date range.')).toBeInTheDocument();
+    expect(screen.queryByTestId('line-chart')).not.toBeInTheDocument();
   });
 
   describe('Index Component - Setup Tutorial Actions', () => {

--- a/app/__tests__/app._index.test.jsx
+++ b/app/__tests__/app._index.test.jsx
@@ -9,6 +9,21 @@ const hoisted = vi.hoisted(() => ({
   authenticateAdminMock: vi.fn(),
 }));
 
+vi.mock("recharts", () => ({
+  LineChart: ({ children }) => <div data-testid="line-chart">{children}</div>,
+  Line: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  Legend: () => null,
+  ResponsiveContainer: ({ children }) => (
+    <div className="recharts-responsive-container" data-testid="recharts-responsive-container">
+      {children}
+    </div>
+  ),
+}));
+
 vi.mock("../shopify.server", () => ({
   default: {
     authenticate: { admin: hoisted.authenticateAdminMock },
@@ -545,6 +560,8 @@ describe("Index Component - Happy Path", () => {
         analyses: [
           {
             calculatedWhen: new Date("2026-01-10"),
+            totalConversions: 5,
+            totalUsers: 100,
             variant: { name: "V" },
             probabilityOfBeingBest: 0.5,
             expectedLoss: 0.02,
@@ -560,7 +577,7 @@ describe("Index Component - Happy Path", () => {
 
     render(<Index />);
     await waitFor(() => {
-      expect(document.querySelector(".recharts-responsive-container")).toBeInTheDocument();
+      expect(screen.getByTestId("recharts-responsive-container")).toBeInTheDocument();
     });
   });
 

--- a/app/__tests__/reportTable.test.jsx
+++ b/app/__tests__/reportTable.test.jsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
 import { useLoaderData } from "react-router";
 
 vi.mock("react-router", () => ({
@@ -36,14 +37,14 @@ vi.mock("../contexts/DateRangeContext", () => ({
 }));
 
 vi.mock("recharts", () => ({
-  LineChart: () => null,
+  LineChart: ({ children }) => <div data-testid="line-chart">{children}</div>,
   Line: () => null,
   XAxis: () => null,
   YAxis: () => null,
   CartesianGrid: () => null,
   Tooltip: () => null,
   Legend: () => null,
-  ResponsiveContainer: () => null,
+  ResponsiveContainer: ({ children }) => <div data-testid="responsive-container">{children}</div>,
   ReferenceLine: () => null,
 }));
 
@@ -135,6 +136,73 @@ describe("Report - renderTableData", () => {
     const { container } = render(<Report />);
     const tableBody = container.querySelector("s-table-body");
     expect(tableBody?.children.length ?? 0).toBe(0);
+  });
+
+  it("shows a no-data indicator instead of charts when no chartable report data exists", async () => {
+    useLoaderData.mockReturnValue(buildLoaderData([]));
+
+    render(<Report />);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("No graph data available for the selected date range.").length,
+      ).toBe(2);
+    });
+
+    expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
+  });
+
+  it("shows the placeholder when report rows have zero conversions or sessions", async () => {
+    const analysis = [
+      makeAnalysisRow({
+        id: 1,
+        variantName: "Control",
+        totalConversions: 0,
+        totalUsers: 300,
+      }),
+      makeAnalysisRow({
+        id: 2,
+        variantName: "Variant A",
+        totalConversions: 12,
+        totalUsers: 0,
+        improvement: 5,
+      }),
+    ];
+
+    useLoaderData.mockReturnValue({
+      ...buildLoaderData(analysis),
+      experiment: {
+        ...buildLoaderData(analysis).experiment,
+        analyses: [
+          {
+            calculatedWhen: "2026-01-02T00:00:00Z",
+            probabilityOfBeingBest: 0,
+            expectedLoss: 0,
+            totalConversions: 0,
+            totalUsers: 300,
+            variant: { name: "Control" },
+          },
+          {
+            calculatedWhen: "2026-01-02T00:00:00Z",
+            probabilityOfBeingBest: 0,
+            expectedLoss: 0,
+            totalConversions: 12,
+            totalUsers: 0,
+            variant: { name: "Variant A" },
+          },
+        ],
+      },
+    });
+
+    render(<Report />);
+
+    await waitFor(() => {
+      expect(
+        screen.getAllByText("No graph data available for the selected date range.").length,
+      ).toBe(2);
+    });
+
+    expect(screen.queryByTestId("line-chart")).not.toBeInTheDocument();
   });
 
   it("displays conversions/users for each row", () => {

--- a/app/components/ConversionsCard.jsx
+++ b/app/components/ConversionsCard.jsx
@@ -2,6 +2,10 @@ import { useState, useEffect, useMemo } from "react";
 import PropTypes from "prop-types";
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 
+const hasNonZeroConversionData = (data) => {
+  return data.some((point) => Number(point?.conversionRate) > 0);
+};
+
 export default function ConversionsCard({ conversionsData, sessionData, hasExperiments }) {
   // Recharts requires the window object to calculate dimensions
   // We use this state variable to ensure the chart only renders on the client side
@@ -40,6 +44,8 @@ export default function ConversionsCard({ conversionsData, sessionData, hasExper
     });
   }, [conversionSessions, trafficSessions, hasExperiments]);
 
+  const hasChartData = hasNonZeroConversionData(chartData);
+
   const totalConversions = conversionSessions.reduce((acc, curr) => acc + (Number(curr.count) || 0), 0);
   const totalSessions = trafficSessions.reduce((acc, curr) => acc + (Number(curr.count) || 0), 0);
   const conversionRate = hasExperiments && totalSessions > 0 ? (totalConversions / totalSessions) * 100 : 0;
@@ -69,7 +75,7 @@ export default function ConversionsCard({ conversionsData, sessionData, hasExper
         }}>
           <div style={{ height: "250px", width: "100%" , minHeight: "250px", position: "relative"}}>
             {isClient ? (
-              chartData.length === 0 ? (
+              !hasChartData ? (
                 <div style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
                   <s-text color="subdued">No conversion data to display yet.</s-text>
                 </div>

--- a/app/components/SessionsCard.jsx
+++ b/app/components/SessionsCard.jsx
@@ -2,6 +2,10 @@ import { useState, useEffect } from "react";
 import PropTypes from "prop-types";
 import { AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 
+const hasNonZeroSessionData = (sessions) => {
+  return sessions.some((row) => Number(row?.count) > 0);
+};
+
 export default function SessionsCard({ sessionData }) {
   // Recharts requires the window object to calculate dimensions
   // We use this state variable to ensure the chart only renders on the client side
@@ -11,6 +15,7 @@ export default function SessionsCard({ sessionData }) {
 
   // Safely destructure sessions and total from sessionData, providing defaults to prevent errors if sessionData is undefined
   const { sessions, total } = sessionData || { sessions: [], total: 0 };
+  const hasChartData = hasNonZeroSessionData(sessions);
 
   const handleFullReport = () => {
     // Cleaner navigation to the native Shopify Analytics report 
@@ -37,7 +42,7 @@ export default function SessionsCard({ sessionData }) {
         }}>
           <div style={{ height: "250px", width: "100%" , minHeight: "250px", position: "relative"}}>
             {isClient ? (
-                sessions.length === 0 ? (
+                !hasChartData ? (
                   <div style={{ height: "100%", display: "flex", alignItems: "center", justifyContent: "center" }}>
                     <s-text color="subdued">No session data to display yet.</s-text>
                   </div>

--- a/app/routes/app._index.jsx
+++ b/app/routes/app._index.jsx
@@ -37,6 +37,35 @@ import { useFetcher } from "react-router";
 import { useAppBridge } from "@shopify/app-bridge-react";
 import { boundary } from "@shopify/shopify-app-react-router/server";
 import { authenticate } from "../shopify.server";
+
+const hasChartData = (data) => {
+  return data.some((point) =>
+    Object.entries(point).some(
+      ([key, value]) => key !== "name" && value !== null && value !== undefined,
+    ),
+  );
+};
+
+const hasNonZeroAnalysisMetrics = (analyses, dateRange) => {
+  if (!Array.isArray(analyses) || !dateRange?.start || !dateRange?.end) {
+    return false;
+  }
+
+  const startDate = new Date(dateRange.start + "T00:00:00");
+  const endDate = new Date(dateRange.end + "T23:59:59");
+
+  return analyses.some((analysis) => {
+    if (!analysis?.calculatedWhen) return false;
+
+    const calculatedWhen = new Date(analysis.calculatedWhen);
+    if (Number.isNaN(calculatedWhen.getTime())) return false;
+    if (calculatedWhen < startDate || calculatedWhen > endDate) {
+      return false;
+    }
+
+    return Number(analysis.totalUsers) > 0 && Number(analysis.totalConversions) > 0;
+  });
+};
 // TODO in the /app/services, add a extension.server.js that will do this "register" part.
 export const loader = async ({ request }) => {
   const {admin, session } = await authenticate.admin(request);
@@ -253,8 +282,12 @@ export default function Index() {
     const expectedLossDataMap = {};
   
     experiment.analyses?.forEach((analysis) => {
-      if (!analysis.calculatedWhen) return; // ensures data actually exists before calling it
-      const dateKey = analysis.calculatedWhen.toLocaleDateString("en-US");
+      if (!analysis?.calculatedWhen || !analysis?.variant?.name) return;
+
+      const calculatedWhen = new Date(analysis.calculatedWhen);
+      if (Number.isNaN(calculatedWhen.getTime())) return;
+
+      const dateKey = calculatedWhen.toLocaleDateString("en-US");
       if (!probabilityDataMap[dateKey]) {
         probabilityDataMap[dateKey] = { name: dateKey };
       }
@@ -292,6 +325,9 @@ export default function Index() {
         })
         .sort((a, b) => new Date(a.name) - new Date(b.name));
     }, [expectedLossData, dateRange]);
+
+      const hasProbabilityChartMetrics = hasNonZeroAnalysisMetrics(experiment.analyses, dateRange);
+      const hasProbabilityChartData = hasProbabilityChartMetrics && hasChartData(filteredPData);
     
   // Button list to navigate to different pages
   return (
@@ -538,7 +574,7 @@ export default function Index() {
           </div>
           
           <s-section heading="Probability To Be The Best">
-            {isClient ? (
+            {isClient && hasProbabilityChartData ? (
               <ResponsiveContainer width="100%" height={400}>
                 <LineChart data={filteredPData}>
                     <CartesianGrid strokeDasharray="3 3" />
@@ -578,7 +614,11 @@ export default function Index() {
                         })}
                       </LineChart>
                     </ResponsiveContainer>
-              ) : (
+              ) : isClient ? (
+                <div style={{ width: "100%", height: 400, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+                    <s-text color="subdued">No graph data available for the selected date range.</s-text>
+                  </div>
+                ) : (
                 <div style={{ width: "100%", height: 400, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
                     <s-text color="subdued">Loading chart...</s-text>
                   </div>

--- a/app/routes/app.reports.$id.jsx
+++ b/app/routes/app.reports.$id.jsx
@@ -38,6 +38,34 @@ import { isLockedStatus, allowedStatusIntents } from "./policies/experimentPolic
 import { authenticate } from "../shopify.server";
 import db from "../db.server";
 
+const hasChartData = (data) => {
+  return data.some((point) =>
+    Object.entries(point).some(
+      ([key, value]) => key !== "name" && value !== null && value !== undefined,
+    ),
+  );
+};
+
+const hasNonZeroAnalysisMetrics = (analyses, dateRange) => {
+  if (!Array.isArray(analyses) || !dateRange?.start || !dateRange?.end) {
+    return false;
+  }
+
+  const startDate = new Date(dateRange.start + "T00:00:00");
+  const endDate = new Date(dateRange.end + "T23:59:59");
+
+  return analyses.some((analysis) => {
+    if (!analysis?.calculatedWhen) return false;
+
+    const calculatedWhen = new Date(analysis.calculatedWhen);
+    if (calculatedWhen < startDate || calculatedWhen > endDate) {
+      return false;
+    }
+
+    return Number(analysis.totalUsers) > 0 && Number(analysis.totalConversions) > 0;
+  });
+};
+
 export const action = async ({ request, params }) => {
   await authenticate.admin(request);
 
@@ -427,7 +455,12 @@ export default function Report() {
   const expectedLossDataMap = {};
 
   experiment.analyses.forEach((analysis) => {
-    const dateKey = analysis.calculatedWhen.toLocaleDateString("en-US");
+    if (!analysis?.calculatedWhen || !analysis?.variant?.name) return;
+
+    const calculatedWhen = new Date(analysis.calculatedWhen);
+    if (Number.isNaN(calculatedWhen.getTime())) return;
+
+    const dateKey = calculatedWhen.toLocaleDateString("en-US");
     if (!probabilityDataMap[dateKey]) {
       probabilityDataMap[dateKey] = { name: dateKey };
     }
@@ -465,6 +498,10 @@ export default function Report() {
       })
       .sort((a, b) => new Date(a.name) - new Date(b.name));
   }, [expectedLossData, dateRange]);
+
+  const hasReportMetrics = hasNonZeroAnalysisMetrics(experiment.analyses, dateRange);
+  const hasProbabilityChartData = hasReportMetrics && hasChartData(filteredPData);
+  const hasExpectedLossChartData = hasReportMetrics && hasChartData(filteredELData);
 
   const heading = experiment?.name ? `Report - ${experiment.name}` : "Report";
   return (
@@ -702,7 +739,7 @@ export default function Report() {
       </s-section>
       {/* Probability Chart Section */}
       <s-section heading="Probability To Be The Best">
-        {isClient ? (
+        {isClient && hasProbabilityChartData ? (
           <ResponsiveContainer width="100%" height={400}>
             <LineChart data={filteredPData}>
               <CartesianGrid strokeDasharray="3 3" />
@@ -748,6 +785,10 @@ export default function Report() {
               })}
             </LineChart>
           </ResponsiveContainer>
+        ) : isClient ? (
+          <div style={{ width: "100%", height: 400, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+             <s-text color="subdued">No graph data available for the selected date range.</s-text>
+          </div>
         ) : (
           <div style={{ width: "100%", height: 400, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
              <s-text color="subdued">Loading chart...</s-text>
@@ -757,7 +798,7 @@ export default function Report() {
 
       {/* Expected Loss Chart Section */}
       <s-section heading="Expected Loss">
-        {isClient ? (
+        {isClient && hasExpectedLossChartData ? (
           <ResponsiveContainer width="100%" height={400}>
             <LineChart data={filteredELData}>
               <CartesianGrid strokeDasharray="3 3" />
@@ -797,6 +838,10 @@ export default function Report() {
               })}
             </LineChart>
           </ResponsiveContainer>
+        ) : isClient ? (
+          <div style={{ width: "100%", height: 400, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+            <s-text color="subdued">No graph data available for the selected date range.</s-text>
+          </div>
         ) : (
           <div style={{ width: "100%", height: 400, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
             <s-text color="subdued">Loading chart...</s-text>


### PR DESCRIPTION
Summary
This fixes the dashboard and report chart empty states so charts are no longer rendered when the underlying data is empty or only contains zero-value points.

What changed
Added a non-zero data guard to the dashboard probability chart
Added non-zero data guards to the conversions and sessions cards
Kept the existing empty-state messaging and made sure it renders instead of an empty chart
Added regression tests for:
no analysis data
zero-only analysis rows
zero-only conversion data
zero-only session data
Validation
Ran npm test -- --run app/__tests__/app._index.test.jsx
Ran npm test -- --run ConversionsCard.test.jsx app/__tests__/SessionsCard.test.jsx
Notes
Root cause was that chart rendering only checked for the presence of rows, not whether those rows contained meaningful non-zero values.