### PR TITLE
Update fly.toml to 1 min machine running

### DIFF
--- a/fly.rev.toml
+++ b/fly.rev.toml
@@ -32,7 +32,7 @@ primary_region = 'sjc'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [[vm]]

--- a/fly.toml
+++ b/fly.toml
@@ -30,7 +30,7 @@ primary_region = 'sjc'
   force_https = true
   auto_stop_machines = 'stop'
   auto_start_machines = true
-  min_machines_running = 0
+  min_machines_running = 1
   processes = ['app']
 
 [[vm]]


### PR DESCRIPTION
This PR makes a simple change to the fly.toml and fly.rev.toml files so that the machine the app is deployed to is required to be running (unless we shut it down). 

This is needed because the server needs to be running to accept analytics data coming from the front end. 