### PR TITLE
Typo fix

### DIFF
--- a/app/routes/app.settings.jsx
+++ b/app/routes/app.settings.jsx
@@ -783,7 +783,7 @@ export default function Settings() {
 
       {/*language*/}
       <s-section heading="Language">
-        <s-select name="language" label="language">
+        <s-select name="Language" label="Language">
           <s-option value="English">English</s-option>
         </s-select>
       </s-section>


### PR DESCRIPTION
sorry if someone can push this through I would appreciate it, this typo has been bugging me for a while on the settings page (not capitalized)

Old:
<img width="469" height="59" alt="Screenshot 2026-04-28 at 2 41 54 PM" src="https://github.com/user-attachments/assets/8175c882-d890-4e91-a0a8-431402a6c57d" />

Fixed:
<img width="838" height="104" alt="Screenshot 2026-04-28 at 2 40 13 PM" src="https://github.com/user-attachments/assets/77dc6113-82c0-4686-82f9-090f236f196b" />
